### PR TITLE
feat: API 응답 표준화 및 ApiResponse wrapper 클래스 구현

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/common/response/ApiResponse.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/common/response/ApiResponse.java
@@ -1,0 +1,75 @@
+package com.mzc.backend.lms.common.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mzc.backend.lms.common.exceptions.ErrorCode;
+
+import java.time.LocalDateTime;
+
+/**
+ * API 응답 표준 래퍼 클래스
+ * <p>
+ * 모든 API 응답을 일관된 형식으로 래핑합니다.
+ * </p>
+ *
+ * @param success 성공 여부
+ * @param data 응답 데이터 (성공 시)
+ * @param error 에러 정보 (실패 시)
+ * @param timestamp 응답 시간
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+        boolean success,
+        T data,
+        ErrorInfo error,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime timestamp
+) {
+
+    /**
+     * 성공 응답 생성 (데이터 포함)
+     */
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null, LocalDateTime.now());
+    }
+
+    /**
+     * 성공 응답 생성 (데이터 없음)
+     */
+    public static <T> ApiResponse<T> ok() {
+        return new ApiResponse<>(true, null, null, LocalDateTime.now());
+    }
+
+    /**
+     * 성공 응답 생성 (메시지만 포함)
+     */
+    public static ApiResponse<MessageResponse> successMessage(String message) {
+        return new ApiResponse<>(true, new MessageResponse(message), null, LocalDateTime.now());
+    }
+
+    /**
+     * 에러 응답 생성 (ErrorCode 사용)
+     */
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(false, null, ErrorInfo.from(errorCode), LocalDateTime.now());
+    }
+
+    /**
+     * 에러 응답 생성 (ErrorCode + 상세 메시지)
+     */
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String detail) {
+        return new ApiResponse<>(false, null, ErrorInfo.from(errorCode, detail), LocalDateTime.now());
+    }
+
+    /**
+     * 에러 응답 생성 (ErrorInfo 직접 사용)
+     */
+    public static <T> ApiResponse<T> error(ErrorInfo errorInfo) {
+        return new ApiResponse<>(false, null, errorInfo, LocalDateTime.now());
+    }
+
+    /**
+     * 메시지 응답용 record
+     */
+    public record MessageResponse(String message) {}
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/common/response/ErrorInfo.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/common/response/ErrorInfo.java
@@ -1,0 +1,97 @@
+package com.mzc.backend.lms.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mzc.backend.lms.common.exceptions.ErrorCode;
+import org.springframework.validation.FieldError;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * API 에러 정보 클래스
+ * <p>
+ * 에러 응답에 포함되는 상세 정보를 담습니다.
+ * </p>
+ *
+ * @param code 에러 코드
+ * @param message 에러 메시지
+ * @param detail 상세 메시지 (선택)
+ * @param fieldErrors 필드별 유효성 검증 에러 (선택)
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorInfo(
+        String code,
+        String message,
+        String detail,
+        List<FieldErrorDetail> fieldErrors
+) {
+
+    /**
+     * ErrorCode로부터 ErrorInfo 생성
+     */
+    public static ErrorInfo from(ErrorCode errorCode) {
+        return new ErrorInfo(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null,
+                null
+        );
+    }
+
+    /**
+     * ErrorCode + 상세 메시지로 ErrorInfo 생성
+     */
+    public static ErrorInfo from(ErrorCode errorCode, String detail) {
+        return new ErrorInfo(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                detail,
+                null
+        );
+    }
+
+    /**
+     * ErrorCode + FieldError 목록으로 ErrorInfo 생성
+     */
+    public static ErrorInfo fromValidation(ErrorCode errorCode, List<FieldError> errors) {
+        List<FieldErrorDetail> fieldErrorDetails = errors.stream()
+                .map(error -> new FieldErrorDetail(
+                        error.getField(),
+                        error.getRejectedValue() != null ? error.getRejectedValue().toString() : null,
+                        error.getDefaultMessage()
+                ))
+                .toList();
+
+        return new ErrorInfo(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null,
+                fieldErrorDetails
+        );
+    }
+
+    /**
+     * 코드, 메시지, Map 형태의 필드 에러로 ErrorInfo 생성
+     */
+    public static ErrorInfo of(String code, String message, Map<String, String> fieldErrors) {
+        List<FieldErrorDetail> details = null;
+        if (fieldErrors != null && !fieldErrors.isEmpty()) {
+            details = fieldErrors.entrySet().stream()
+                    .map(entry -> new FieldErrorDetail(entry.getKey(), null, entry.getValue()))
+                    .toList();
+        }
+
+        return new ErrorInfo(code, message, null, details);
+    }
+
+    /**
+     * 필드 에러 상세 정보
+     */
+    public record FieldErrorDetail(
+            String field,
+            String rejectedValue,
+            String message
+    ) {}
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/academy/controller/AcademicTermCurrentController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/academy/controller/AcademicTermCurrentController.java
@@ -1,19 +1,19 @@
 package com.mzc.backend.lms.domains.academy.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.academy.entity.AcademicTerm;
 import com.mzc.backend.lms.domains.academy.repository.AcademicTermRepository;
 import com.mzc.backend.lms.domains.course.course.dto.AcademicTermDto;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 현재 학기 조회 (공통)
@@ -29,42 +29,24 @@ public class AcademicTermCurrentController {
     private final AcademicTermRepository academicTermRepository;
 
     @GetMapping("/current")
-    public ResponseEntity<?> getCurrentAcademicTerm(Authentication authentication) {
-        try {
-            if (authentication == null) {
-                return ResponseEntity.status(401).body(error("인증이 필요합니다."));
-            }
-
-            AcademicTerm t = academicTermRepository.findCurrentTerms(LocalDate.now()).stream()
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("현재 날짜에 해당하는 학기가 없습니다."));
-
-            AcademicTermDto data = AcademicTermDto.builder()
-                    .id(t.getId())
-                    .year(t.getYear())
-                    .termType(t.getTermType())
-                    .startDate(t.getStartDate())
-                    .endDate(t.getEndDate())
-                    .build();
-
-            Map<String, Object> res = new HashMap<>();
-            res.put("success", true);
-            res.put("data", data);
-            return ResponseEntity.ok(res);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("현재 학기 조회 실패", e);
-            return ResponseEntity.internalServerError().body(error("현재 학기 조회에 실패했습니다."));
+    public ResponseEntity<ApiResponse<AcademicTermDto>> getCurrentAcademicTerm(
+            @AuthenticationPrincipal Long userId) {
+        if (userId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> error(String message) {
-        Map<String, Object> res = new HashMap<>();
-        res.put("success", false);
-        res.put("message", message);
-        return res;
+        AcademicTerm t = academicTermRepository.findCurrentTerms(LocalDate.now()).stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("현재 날짜에 해당하는 학기가 없습니다."));
+
+        AcademicTermDto data = AcademicTermDto.builder()
+                .id(t.getId())
+                .year(t.getYear())
+                .termType(t.getTermType())
+                .startDate(t.getStartDate())
+                .endDate(t.getEndDate())
+                .build();
+
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/academy/controller/ProfessorAcademicTermController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/academy/controller/ProfessorAcademicTermController.java
@@ -1,7 +1,9 @@
 package com.mzc.backend.lms.domains.academy.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.academy.service.ProfessorAcademicTermService;
 import com.mzc.backend.lms.domains.course.course.dto.AcademicTermDto;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -10,9 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -26,32 +26,12 @@ public class ProfessorAcademicTermController {
      * 교수 본인 담당 학기 목록 조회 (지난 학기 강의/성적 조회용 academicTermId 확인)
      */
     @GetMapping
-    public ResponseEntity<?> listMyAcademicTerms(@AuthenticationPrincipal Long professorId) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(401).body(error("인증이 필요합니다."));
-            }
-            List<AcademicTermDto> data = professorAcademicTermService.listMyAcademicTerms(professorId);
-
-            Map<String, Object> res = new HashMap<>();
-            res.put("success", true);
-            res.put("data", data);
-            res.put("count", data.size());
-            return ResponseEntity.ok(res);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("교수 학기 목록 조회 실패", e);
-            return ResponseEntity.internalServerError().body(error("교수 학기 목록 조회에 실패했습니다."));
+    public ResponseEntity<ApiResponse<List<AcademicTermDto>>> listMyAcademicTerms(
+            @AuthenticationPrincipal Long professorId) {
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
-    }
-
-    private Map<String, Object> error(String message) {
-        Map<String, Object> res = new HashMap<>();
-        res.put("success", false);
-        res.put("message", message);
-        return res;
+        List<AcademicTermDto> data = professorAcademicTermService.listMyAcademicTerms(professorId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/academy/controller/StudentAcademicTermController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/academy/controller/StudentAcademicTermController.java
@@ -1,7 +1,9 @@
 package com.mzc.backend.lms.domains.academy.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.academy.service.StudentAcademicTermService;
 import com.mzc.backend.lms.domains.course.course.dto.AcademicTermDto;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,9 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -27,57 +27,25 @@ public class StudentAcademicTermController {
      * 학생 본인 수강 학기 목록 조회 (성적 조회용 academicTermId 확인)
      */
     @GetMapping
-    public ResponseEntity<?> listMyAcademicTerms(@AuthenticationPrincipal Long studentId) {
-        try {
-            if (studentId == null) {
-                return ResponseEntity.status(401).body(error("인증이 필요합니다."));
-            }
-
-            List<AcademicTermDto> data = studentAcademicTermService.listMyAcademicTerms(studentId);
-
-            Map<String, Object> res = new HashMap<>();
-            res.put("success", true);
-            res.put("data", data);
-            res.put("count", data.size());
-            return ResponseEntity.ok(res);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("학생 학기 목록 조회 실패 studentId={}", studentId, e);
-            return ResponseEntity.internalServerError().body(error("학생 학기 목록 조회에 실패했습니다."));
+    public ResponseEntity<ApiResponse<List<AcademicTermDto>>> listMyAcademicTerms(
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+        List<AcademicTermDto> data = studentAcademicTermService.listMyAcademicTerms(studentId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
      * 현재 학기 조회 (활성화된 수강신청 기간 ENROLLMENT 기준)
      */
     @GetMapping("/current")
-    public ResponseEntity<?> getCurrentAcademicTerm(@AuthenticationPrincipal Long studentId) {
-        try {
-            if (studentId == null) {
-                return ResponseEntity.status(401).body(error("인증이 필요합니다."));
-            }
-
-            AcademicTermDto data = studentAcademicTermService.getCurrentAcademicTerm(LocalDateTime.now());
-
-            Map<String, Object> res = new HashMap<>();
-            res.put("success", true);
-            res.put("data", data);
-            return ResponseEntity.ok(res);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("학생 현재 학기 조회 실패 studentId={}", studentId, e);
-            return ResponseEntity.internalServerError().body(error("학생 현재 학기 조회에 실패했습니다."));
+    public ResponseEntity<ApiResponse<AcademicTermDto>> getCurrentAcademicTerm(
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
-    }
-
-    private Map<String, Object> error(String message) {
-        Map<String, Object> res = new HashMap<>();
-        res.put("success", false);
-        res.put("message", message);
-        return res;
+        AcademicTermDto data = studentAcademicTermService.getCurrentAcademicTerm(LocalDateTime.now());
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/controller/AssessmentProfessorController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/controller/AssessmentProfessorController.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.assessment.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.assessment.dto.request.AssessmentCreateRequestDto;
 import com.mzc.backend.lms.domains.assessment.dto.request.AssessmentUpdateRequestDto;
 import com.mzc.backend.lms.domains.assessment.dto.request.AttemptGradeRequestDto;
@@ -11,17 +12,16 @@ import com.mzc.backend.lms.domains.assessment.dto.response.ProfessorAttemptListI
 import com.mzc.backend.lms.domains.assessment.enums.AssessmentType;
 import com.mzc.backend.lms.domains.assessment.service.AssessmentService;
 import com.mzc.backend.lms.domains.board.enums.BoardType;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 교수용 시험/퀴즈 관리 API
@@ -39,21 +39,16 @@ public class AssessmentProfessorController {
      * - 교수는 시작 전 포함 전체 조회 가능(미리보기)
      */
     @GetMapping("/api/v1/professor/exams")
-    public ResponseEntity<?> list(
+    public ResponseEntity<ApiResponse<List<AssessmentListItemResponseDto>>> list(
             @RequestParam Long courseId,
             @RequestParam AssessmentType examType,
-            Authentication authentication
+            @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            List<AssessmentListItemResponseDto> data = assessmentService.listForProfessor(courseId, examType, professorId.longValue());
-            return ResponseEntity.ok(success(data, null));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("교수 시험/퀴즈 목록 조회 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+        List<AssessmentListItemResponseDto> data = assessmentService.listForProfessor(courseId, examType, professorId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -62,20 +57,15 @@ public class AssessmentProfessorController {
      * - 교수는 questionData(정답 포함) 원본 조회 가능
      */
     @GetMapping("/api/v1/professor/exams/{examId}")
-    public ResponseEntity<?> detail(
+    public ResponseEntity<ApiResponse<AssessmentDetailResponseDto>> detail(
             @PathVariable Long examId,
-            Authentication authentication
+            @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            AssessmentDetailResponseDto data = assessmentService.getDetailForProfessor(examId, professorId.longValue());
-            return ResponseEntity.ok(success(data, null));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("교수 시험/퀴즈 상세 조회 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+        AssessmentDetailResponseDto data = assessmentService.getDetailForProfessor(examId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -84,22 +74,17 @@ public class AssessmentProfessorController {
      * - status(optional): ALL | SUBMITTED | IN_PROGRESS (기본값 ALL)
      */
     @GetMapping("/api/v1/professor/exams/{examId}/attempts")
-    public ResponseEntity<?> listAttempts(
+    public ResponseEntity<ApiResponse<List<ProfessorAttemptListItemResponseDto>>> listAttempts(
             @PathVariable Long examId,
             @RequestParam(required = false, defaultValue = "ALL") String status,
-            Authentication authentication
+            @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            List<ProfessorAttemptListItemResponseDto> data =
-                    assessmentService.listAttemptsForProfessor(examId, status, professorId.longValue());
-            return ResponseEntity.ok(success(data, null));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("교수 응시 목록 조회 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+        List<ProfessorAttemptListItemResponseDto> data =
+                assessmentService.listAttemptsForProfessor(examId, status, professorId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -107,21 +92,16 @@ public class AssessmentProfessorController {
      * - 예: GET /api/v1/professor/exams/results/{attemptId}
      */
     @GetMapping("/api/v1/professor/exams/results/{attemptId}")
-    public ResponseEntity<?> attemptDetail(
+    public ResponseEntity<ApiResponse<ProfessorAttemptDetailResponseDto>> attemptDetail(
             @PathVariable Long attemptId,
-            Authentication authentication
+            @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            ProfessorAttemptDetailResponseDto data =
-                    assessmentService.getAttemptDetailForProfessor(attemptId, professorId.longValue());
-            return ResponseEntity.ok(success(data, null));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("교수 응시 상세 조회 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+        ProfessorAttemptDetailResponseDto data =
+                assessmentService.getAttemptDetailForProfessor(attemptId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -129,21 +109,16 @@ public class AssessmentProfessorController {
      * - 예: POST /api/v1/boards/QUIZ/exams
      */
     @PostMapping("/api/v1/boards/{boardType}/exams")
-    public ResponseEntity<?> create(
+    public ResponseEntity<ApiResponse<AssessmentDetailResponseDto>> create(
             @PathVariable String boardType,
             @Valid @RequestBody AssessmentCreateRequestDto request,
-            Authentication authentication) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            BoardType bt = BoardType.valueOf(boardType);
-            AssessmentDetailResponseDto data = assessmentService.create(bt, request, professorId.longValue());
-            return ResponseEntity.status(HttpStatus.CREATED).body(success(data, "생성되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("시험/퀴즈 생성 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+            @AuthenticationPrincipal Long professorId) {
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+        BoardType bt = BoardType.valueOf(boardType);
+        AssessmentDetailResponseDto data = assessmentService.create(bt, request, professorId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(data));
     }
 
     /**
@@ -151,20 +126,15 @@ public class AssessmentProfessorController {
      * - 예: PUT /api/v1/exams/{examId}/edit
      */
     @PutMapping("/api/v1/exams/{examId}/edit")
-    public ResponseEntity<?> update(
+    public ResponseEntity<ApiResponse<AssessmentDetailResponseDto>> update(
             @PathVariable Long examId,
             @Valid @RequestBody AssessmentUpdateRequestDto request,
-            Authentication authentication) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            AssessmentDetailResponseDto data = assessmentService.update(examId, request, professorId.longValue());
-            return ResponseEntity.ok(success(data, "수정되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("시험/퀴즈 수정 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+            @AuthenticationPrincipal Long professorId) {
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+        AssessmentDetailResponseDto data = assessmentService.update(examId, request, professorId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -172,19 +142,14 @@ public class AssessmentProfessorController {
      * - 예: DELETE /api/v1/exams/{examId}/delete
      */
     @DeleteMapping("/api/v1/exams/{examId}/delete")
-    public ResponseEntity<?> delete(
+    public ResponseEntity<ApiResponse<Void>> delete(
             @PathVariable Long examId,
-            Authentication authentication) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            assessmentService.delete(examId, professorId.longValue());
-            return ResponseEntity.ok(success(null, "삭제되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("시험/퀴즈 삭제 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+            @AuthenticationPrincipal Long professorId) {
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+        assessmentService.delete(examId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
@@ -192,39 +157,15 @@ public class AssessmentProfessorController {
      * - 퀴즈는 자동채점이므로 본 API 대상이 아님
      */
     @PutMapping("/api/v1/exams/results/{attemptId}/grade")
-    public ResponseEntity<?> gradeAttempt(
+    public ResponseEntity<ApiResponse<AttemptGradeResponseDto>> gradeAttempt(
             @PathVariable Long attemptId,
             @Valid @RequestBody AttemptGradeRequestDto request,
-            Authentication authentication
+            @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            Long professorId = (Long) authentication.getPrincipal();
-            AttemptGradeResponseDto data = assessmentService.gradeAttempt(attemptId, request, professorId.longValue());
-            return ResponseEntity.ok(success(data, "채점되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("시험 채점 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
-    }
-
-    private Map<String, Object> success(Object data, String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        if (message != null) {
-            response.put("message", message);
-        }
-        return response;
-    }
-
-    private Map<String, Object> error(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        AttemptGradeResponseDto data = assessmentService.gradeAttempt(attemptId, request, professorId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/controller/AssessmentStudentController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/controller/AssessmentStudentController.java
@@ -1,20 +1,19 @@
 package com.mzc.backend.lms.domains.assessment.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.assessment.dto.request.AttemptSubmitRequestDto;
 import com.mzc.backend.lms.domains.assessment.dto.response.*;
 import com.mzc.backend.lms.domains.assessment.enums.AssessmentType;
 import com.mzc.backend.lms.domains.assessment.service.AssessmentService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 학생용 시험/퀴즈 조회/응시 API
@@ -32,20 +31,15 @@ public class AssessmentStudentController {
      * - 학생에게는 시작시간 전 항목 숨김
      */
     @GetMapping("/api/v1/exams")
-    public ResponseEntity<?> list(
+    public ResponseEntity<ApiResponse<List<AssessmentListItemResponseDto>>> list(
             @RequestParam Long courseId,
             @RequestParam AssessmentType examType,
-            Authentication authentication) {
-        try {
-            Long studentId = (Long) authentication.getPrincipal();
-            List<AssessmentListItemResponseDto> data = assessmentService.listForStudent(courseId, examType, studentId.longValue());
-            return ResponseEntity.ok(success(data));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("시험/퀴즈 목록 조회 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+        List<AssessmentListItemResponseDto> data = assessmentService.listForStudent(courseId, examType, studentId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -53,19 +47,14 @@ public class AssessmentStudentController {
      * - 학생에게는 정답 마스킹된 questionData 제공
      */
     @GetMapping("/api/v1/exams/{examId}")
-    public ResponseEntity<?> detail(
+    public ResponseEntity<ApiResponse<AssessmentDetailResponseDto>> detail(
             @PathVariable Long examId,
-            Authentication authentication) {
-        try {
-            Long studentId = (Long) authentication.getPrincipal();
-            AssessmentDetailResponseDto data = assessmentService.getDetailForStudent(examId, studentId.longValue());
-            return ResponseEntity.ok(success(data));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("시험/퀴즈 상세 조회 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+        AssessmentDetailResponseDto data = assessmentService.getDetailForStudent(examId, studentId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -74,19 +63,14 @@ public class AssessmentStudentController {
      * - QuizAttempt = exam_results 생성/조회
      */
     @PostMapping("/api/v1/exams/{examId}/start")
-    public ResponseEntity<?> start(
+    public ResponseEntity<ApiResponse<AttemptStartResponseDto>> start(
             @PathVariable Long examId,
-            Authentication authentication) {
-        try {
-            Long studentId = (Long) authentication.getPrincipal();
-            AttemptStartResponseDto data = assessmentService.startAttempt(examId, studentId.longValue());
-            return ResponseEntity.ok(success(data));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("응시 시작 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+        AttemptStartResponseDto data = assessmentService.startAttempt(examId, studentId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 
     /**
@@ -94,35 +78,14 @@ public class AssessmentStudentController {
      * - late면 0점 처리
      */
     @PostMapping("/api/v1/exams/results/{attemptId}/submit")
-    public ResponseEntity<?> submit(
+    public ResponseEntity<ApiResponse<AttemptSubmitResponseDto>> submit(
             @PathVariable Long attemptId,
             @Valid @RequestBody AttemptSubmitRequestDto request,
-            Authentication authentication) {
-        try {
-            Long studentId = (Long) authentication.getPrincipal();
-            AttemptSubmitResponseDto data = assessmentService.submitAttempt(attemptId, request, studentId.longValue());
-            return ResponseEntity.ok(success(data));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("제출 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
-    }
-
-    private Map<String, Object> success(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
-
-    private Map<String, Object> error(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        AttemptSubmitResponseDto data = assessmentService.submitAttempt(attemptId, request, studentId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/controller/ProfessorAttendanceController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/controller/ProfessorAttendanceController.java
@@ -1,19 +1,18 @@
 package com.mzc.backend.lms.domains.attendance.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.attendance.dto.CourseAttendanceOverviewDto;
 import com.mzc.backend.lms.domains.attendance.dto.StudentAttendanceDto;
 import com.mzc.backend.lms.domains.attendance.dto.WeekStudentAttendanceDto;
 import com.mzc.backend.lms.domains.attendance.service.AttendanceService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 교수용 출석 관리 컨트롤러
@@ -31,27 +30,15 @@ public class ProfessorAttendanceController {
      * GET /api/v1/professor/courses/{courseId}/attendance
      */
     @GetMapping("/attendance")
-    public ResponseEntity<?> getCourseAttendanceOverview(
+    public ResponseEntity<ApiResponse<CourseAttendanceOverviewDto>> getCourseAttendanceOverview(
             @PathVariable Long courseId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("Login required"));
-            }
-
-            CourseAttendanceOverviewDto response = attendanceService.getProfessorCourseAttendance(professorId, courseId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-
-        } catch (IllegalArgumentException e) {
-            log.warn("Failed to get course attendance: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("Failed to get course attendance: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        CourseAttendanceOverviewDto response = attendanceService.getProfessorCourseAttendance(professorId, courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
@@ -59,27 +46,15 @@ public class ProfessorAttendanceController {
      * GET /api/v1/professor/courses/{courseId}/attendance/students
      */
     @GetMapping("/attendance/students")
-    public ResponseEntity<?> getStudentAttendances(
+    public ResponseEntity<ApiResponse<List<StudentAttendanceDto>>> getStudentAttendances(
             @PathVariable Long courseId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("Login required"));
-            }
-
-            List<StudentAttendanceDto> response = attendanceService.getProfessorStudentAttendances(professorId, courseId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-
-        } catch (IllegalArgumentException e) {
-            log.warn("Failed to get student attendances: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("Failed to get student attendances: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        List<StudentAttendanceDto> response = attendanceService.getProfessorStudentAttendances(professorId, courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
@@ -87,41 +62,15 @@ public class ProfessorAttendanceController {
      * GET /api/v1/professor/courses/{courseId}/weeks/{weekId}/attendance
      */
     @GetMapping("/weeks/{weekId}/attendance")
-    public ResponseEntity<?> getWeekStudentAttendances(
+    public ResponseEntity<ApiResponse<List<WeekStudentAttendanceDto>>> getWeekStudentAttendances(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("Login required"));
-            }
-
-            List<WeekStudentAttendanceDto> response = attendanceService.getProfessorWeekAttendances(professorId, courseId, weekId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-
-        } catch (IllegalArgumentException e) {
-            log.warn("Failed to get week attendance: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("Failed to get week attendance: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        List<WeekStudentAttendanceDto> response = attendanceService.getProfessorWeekAttendances(professorId, courseId, weekId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/controller/StudentAttendanceController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/controller/StudentAttendanceController.java
@@ -1,18 +1,19 @@
 package com.mzc.backend.lms.domains.attendance.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.attendance.dto.CourseAttendanceDto;
 import com.mzc.backend.lms.domains.attendance.dto.CourseAttendanceSummaryDto;
+import com.mzc.backend.lms.domains.attendance.dto.WeekAttendanceDto;
+import com.mzc.backend.lms.domains.attendance.exception.AttendanceException;
 import com.mzc.backend.lms.domains.attendance.service.AttendanceService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 학생용 출석 조회 컨트롤러
@@ -30,25 +31,14 @@ public class StudentAttendanceController {
      * GET /api/v1/attendance/my
      */
     @GetMapping("/my")
-    public ResponseEntity<?> getMyAttendance(@AuthenticationPrincipal Long studentId) {
-        try {
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("Login required"));
-            }
-
-            List<CourseAttendanceSummaryDto> response = attendanceService.getStudentAllAttendance(studentId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-
-        } catch (IllegalArgumentException e) {
-            log.warn("Failed to get attendance: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("Failed to get attendance: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+    public ResponseEntity<ApiResponse<List<CourseAttendanceSummaryDto>>> getMyAttendance(
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        List<CourseAttendanceSummaryDto> response = attendanceService.getStudentAllAttendance(studentId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
@@ -56,27 +46,15 @@ public class StudentAttendanceController {
      * GET /api/v1/attendance/courses/{courseId}
      */
     @GetMapping("/courses/{courseId}")
-    public ResponseEntity<?> getCourseAttendance(
+    public ResponseEntity<ApiResponse<CourseAttendanceDto>> getCourseAttendance(
             @PathVariable Long courseId,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("Login required"));
-            }
-
-            CourseAttendanceDto response = attendanceService.getStudentCourseAttendance(studentId, courseId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-
-        } catch (IllegalArgumentException e) {
-            log.warn("Failed to get course attendance: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("Failed to get course attendance: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        CourseAttendanceDto response = attendanceService.getStudentCourseAttendance(studentId, courseId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
@@ -84,47 +62,20 @@ public class StudentAttendanceController {
      * GET /api/v1/attendance/courses/{courseId}/weeks/{weekId}
      */
     @GetMapping("/courses/{courseId}/weeks/{weekId}")
-    public ResponseEntity<?> getWeekAttendanceDetail(
+    public ResponseEntity<ApiResponse<WeekAttendanceDto>> getWeekAttendanceDetail(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("Login required"));
-            }
-
-            // 강의 출석 조회 후 해당 주차 정보만 필터링
-            CourseAttendanceDto courseAttendance = attendanceService.getStudentCourseAttendance(studentId, courseId);
-            var weekAttendance = courseAttendance.getWeekAttendances().stream()
-                    .filter(w -> w.getWeekId().equals(weekId))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Week not found: " + weekId));
-
-            return ResponseEntity.ok(createSuccessResponse(weekAttendance));
-
-        } catch (IllegalArgumentException e) {
-            log.warn("Failed to get week attendance: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("Failed to get week attendance: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
+        CourseAttendanceDto courseAttendance = attendanceService.getStudentCourseAttendance(studentId, courseId);
+        WeekAttendanceDto weekAttendance = courseAttendance.getWeekAttendances().stream()
+                .filter(w -> w.getWeekId().equals(weekId))
+                .findFirst()
+                .orElseThrow(() -> AttendanceException.weekNotFound(weekId));
 
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        return ResponseEntity.ok(ApiResponse.success(weekAttendance));
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/exception/AttendanceErrorCode.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/exception/AttendanceErrorCode.java
@@ -15,6 +15,7 @@ public enum AttendanceErrorCode implements DomainErrorCode {
 
     // 출석 관련 (ATTENDANCE_0XX)
     ATTENDANCE_NOT_FOUND("ATTENDANCE_001", "출석 기록을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    WEEK_NOT_FOUND("ATTENDANCE_005", "주차를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     ALREADY_CHECKED("ATTENDANCE_002", "이미 출석 체크되었습니다", HttpStatus.CONFLICT),
     CHECK_TIME_EXPIRED("ATTENDANCE_003", "출석 체크 시간이 종료되었습니다", HttpStatus.BAD_REQUEST),
     NOT_CHECK_TIME("ATTENDANCE_004", "출석 체크 시간이 아닙니다", HttpStatus.BAD_REQUEST),

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/exception/AttendanceException.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/exception/AttendanceException.java
@@ -48,6 +48,11 @@ public class AttendanceException extends CommonException {
             String.format("출석 ID: %d", attendanceId));
     }
 
+    public static AttendanceException weekNotFound(Long weekId) {
+        return new AttendanceException(AttendanceErrorCode.WEEK_NOT_FOUND,
+            String.format("주차 ID: %d", weekId));
+    }
+
     public static AttendanceException alreadyChecked(Long userId, Long sessionId) {
         return new AttendanceException(AttendanceErrorCode.ALREADY_CHECKED,
             String.format("사용자 ID: %d, 세션 ID: %d", userId, sessionId));

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/CourseWeekContentController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/CourseWeekContentController.java
@@ -1,7 +1,9 @@
 package com.mzc.backend.lms.domains.course.course.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.course.dto.*;
 import com.mzc.backend.lms.domains.course.course.service.CourseWeekContentService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -9,9 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 주차별 콘텐츠 관리 컨트롤러
@@ -28,278 +28,156 @@ public class CourseWeekContentController {
      * 주차 생성
      */
     @PostMapping
-    public ResponseEntity<?> createWeek(
+    public ResponseEntity<ApiResponse<WeekDto>> createWeek(
             @PathVariable Long courseId,
             @RequestBody CreateWeekRequestDto request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("주차 생성 요청: courseId={}, weekNumber={}, professorId={}",
-                    courseId, request.getWeekNumber(), professorId);
-
-            WeekDto response = courseWeekContentService.createWeek(courseId, request, professorId);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(createSuccessResponse(response, "주차가 생성되었습니다"));
-        } catch (IllegalArgumentException e) {
-            log.warn("주차 생성 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("주차 생성 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("주차 생성 요청: courseId={}, weekNumber={}, professorId={}",
+                courseId, request.getWeekNumber(), professorId);
+
+        WeekDto response = courseWeekContentService.createWeek(courseId, request, professorId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     /**
      * 주차 수정
      */
     @PutMapping("/{weekId}")
-    public ResponseEntity<?> updateWeek(
+    public ResponseEntity<ApiResponse<WeekDto>> updateWeek(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @RequestBody UpdateWeekRequestDto request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("주차 수정 요청: courseId={}, weekId={}, professorId={}", courseId, weekId, professorId);
-
-            WeekDto response = courseWeekContentService.updateWeek(courseId, weekId, request, professorId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("주차 수정 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("주차 수정 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("주차 수정 요청: courseId={}, weekId={}, professorId={}", courseId, weekId, professorId);
+
+        WeekDto response = courseWeekContentService.updateWeek(courseId, weekId, request, professorId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 주차 삭제
      */
     @DeleteMapping("/{weekId}")
-    public ResponseEntity<?> deleteWeek(
+    public ResponseEntity<ApiResponse<Void>> deleteWeek(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("주차 삭제 요청: courseId={}, weekId={}, professorId={}", courseId, weekId, professorId);
-
-            courseWeekContentService.deleteWeek(courseId, weekId, professorId);
-            return ResponseEntity.ok(createSuccessResponse(null, "주차가 삭제되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("주차 삭제 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("주차 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("주차 삭제 요청: courseId={}, weekId={}, professorId={}", courseId, weekId, professorId);
+
+        courseWeekContentService.deleteWeek(courseId, weekId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 콘텐츠 등록
      */
     @PostMapping("/{weekId}/contents")
-    public ResponseEntity<?> createContent(
+    public ResponseEntity<ApiResponse<WeekContentDto>> createContent(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @RequestBody CreateWeekContentRequestDto request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("콘텐츠 등록 요청: courseId={}, weekId={}, contentType={}, professorId={}",
-                    courseId, weekId, request.getContentType(), professorId);
-
-            WeekContentDto response = courseWeekContentService.createContent(courseId, weekId, request, professorId);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(createSuccessResponse(response, "콘텐츠가 추가되었습니다"));
-        } catch (IllegalArgumentException e) {
-            log.warn("콘텐츠 등록 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("콘텐츠 등록 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("콘텐츠 등록 요청: courseId={}, weekId={}, contentType={}, professorId={}",
+                courseId, weekId, request.getContentType(), professorId);
+
+        WeekContentDto response = courseWeekContentService.createContent(courseId, weekId, request, professorId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     /**
      * 콘텐츠 수정
      */
     @PutMapping("/{weekId}/contents/{contentId}")
-    public ResponseEntity<?> updateContent(
+    public ResponseEntity<ApiResponse<WeekContentDto>> updateContent(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @PathVariable Long contentId,
             @RequestBody UpdateWeekContentRequestDto request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("콘텐츠 수정 요청: courseId={}, weekId={}, contentId={}, professorId={}",
-                    courseId, weekId, contentId, professorId);
-
-            WeekContentDto response = courseWeekContentService.updateContent(
-                    courseId, weekId, contentId, request, professorId);
-            return ResponseEntity.ok(createSuccessResponse(response, "콘텐츠가 수정되었습니다"));
-        } catch (IllegalArgumentException e) {
-            log.warn("콘텐츠 수정 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("콘텐츠 수정 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("콘텐츠 수정 요청: courseId={}, weekId={}, contentId={}, professorId={}",
+                courseId, weekId, contentId, professorId);
+
+        WeekContentDto response = courseWeekContentService.updateContent(
+                courseId, weekId, contentId, request, professorId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 콘텐츠 삭제
      */
     @DeleteMapping("/{weekId}/contents/{contentId}")
-    public ResponseEntity<?> deleteContent(
+    public ResponseEntity<ApiResponse<Void>> deleteContent(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @PathVariable Long contentId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("콘텐츠 삭제 요청: courseId={}, weekId={}, contentId={}, professorId={}",
-                    courseId, weekId, contentId, professorId);
-
-            courseWeekContentService.deleteContent(courseId, weekId, contentId, professorId);
-            return ResponseEntity.ok(createSuccessResponse(null, "콘텐츠가 삭제되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("콘텐츠 삭제 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("콘텐츠 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("콘텐츠 삭제 요청: courseId={}, weekId={}, contentId={}, professorId={}",
+                courseId, weekId, contentId, professorId);
+
+        courseWeekContentService.deleteContent(courseId, weekId, contentId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 강의 주차 목록 조회 (교수/수강중 학생)
      */
     @GetMapping
-    public ResponseEntity<?> getWeeks(
+    public ResponseEntity<ApiResponse<List<WeekListResponseDto>>> getWeeks(
             @PathVariable Long courseId,
             @AuthenticationPrincipal Long requesterId) {
-        try {
-            // 인증 확인
-            if (requesterId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("강의 주차 목록 조회: courseId={}, requesterId={}", courseId, requesterId);
-
-            List<WeekListResponseDto> response = courseWeekContentService.getWeeks(courseId, requesterId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("강의 주차 목록 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("강의 주차 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (requesterId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("강의 주차 목록 조회: courseId={}, requesterId={}", courseId, requesterId);
+
+        List<WeekListResponseDto> response = courseWeekContentService.getWeeks(courseId, requesterId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 주차별 콘텐츠 목록 조회
      */
     @GetMapping("/{weekId}/contents")
-    public ResponseEntity<?> getWeekContents(
+    public ResponseEntity<ApiResponse<WeekContentsResponseDto>> getWeekContents(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             @AuthenticationPrincipal Long requesterId) {
-        try {
-            // 인증 확인
-            if (requesterId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("주차별 콘텐츠 목록 조회: courseId={}, weekId={}, requesterId={}",
-                    courseId, weekId, requesterId);
-
-            WeekContentsResponseDto response = courseWeekContentService.getWeekContents(
-                    courseId, weekId, requesterId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("주차별 콘텐츠 목록 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("주차별 콘텐츠 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (requesterId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    /**
-     * 공통 성공 응답
-     */
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
+        log.debug("주차별 콘텐츠 목록 조회: courseId={}, weekId={}, requesterId={}",
+                courseId, weekId, requesterId);
 
-    private Map<String, Object> createSuccessResponse(Object data, String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        response.put("message", message);
-        return response;
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        WeekContentsResponseDto response = courseWeekContentService.getWeekContents(
+                courseId, weekId, requesterId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/CourseWeekReadController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/CourseWeekReadController.java
@@ -1,11 +1,12 @@
 package com.mzc.backend.lms.domains.course.course.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.course.dto.WeekListResponseDto;
 import com.mzc.backend.lms.domains.course.course.dto.WeekContentsResponseDto;
 import com.mzc.backend.lms.domains.course.course.service.CourseWeekContentService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,9 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 주차 목록 조회 컨트롤러 (학생/교수 공용)
@@ -33,72 +32,34 @@ public class CourseWeekReadController {
      * n주차 목록 조회 (수강중 학생 / 담당 교수)
      */
     @GetMapping("/{courseId}/weeks")
-    public ResponseEntity<?> getWeeks(
+    public ResponseEntity<ApiResponse<List<WeekListResponseDto>>> getWeeks(
             @PathVariable Long courseId,
             Authentication authentication
     ) {
-        try {
-            if (authentication == null || authentication.getPrincipal() == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            Long requesterId = (Long) authentication.getPrincipal();
-            List<WeekListResponseDto> response = courseWeekContentService.getWeeks(courseId, requesterId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("주차 목록 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("주차 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류"));
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw AuthException.unauthorized();
         }
+
+        Long requesterId = (Long) authentication.getPrincipal();
+        List<WeekListResponseDto> response = courseWeekContentService.getWeeks(courseId, requesterId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 주차별 콘텐츠 목록 조회 (수강중 학생 / 담당 교수)
      */
     @GetMapping("/{courseId}/weeks/{weekId}/contents")
-    public ResponseEntity<?> getWeekContents(
+    public ResponseEntity<ApiResponse<WeekContentsResponseDto>> getWeekContents(
             @PathVariable Long courseId,
             @PathVariable Long weekId,
             Authentication authentication
     ) {
-        try {
-            if (authentication == null || authentication.getPrincipal() == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            Long requesterId = (Long) authentication.getPrincipal();
-            WeekContentsResponseDto response = courseWeekContentService.getWeekContents(courseId, weekId, requesterId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("주차별 콘텐츠 목록 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("주차별 콘텐츠 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류"));
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        Long requesterId = (Long) authentication.getPrincipal();
+        WeekContentsResponseDto response = courseWeekContentService.getWeekContents(courseId, weekId, requesterId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/ProfessorCourseController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/ProfessorCourseController.java
@@ -1,16 +1,15 @@
 package com.mzc.backend.lms.domains.course.course.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.course.dto.*;
 import com.mzc.backend.lms.domains.course.course.service.ProfessorCourseService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 교수 강의 관리 컨트롤러
@@ -27,169 +26,86 @@ public class ProfessorCourseController {
      * 강의 개설
      */
     @PostMapping
-    public ResponseEntity<?> createCourse(
+    public ResponseEntity<ApiResponse<CreateCourseResponseDto>> createCourse(
             @RequestBody CreateCourseRequestDto request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("강의 개설 요청: professorId={}", professorId);
-
-            CreateCourseResponseDto response = professorCourseService.createCourse(request, professorId);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("강의 개설 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("강의 개설 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("강의 개설 요청: professorId={}", professorId);
+
+        CreateCourseResponseDto response = professorCourseService.createCourse(request, professorId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     /**
      * 강의 수정
      */
     @PutMapping("/{courseId}")
-    public ResponseEntity<?> updateCourse(
+    public ResponseEntity<ApiResponse<CreateCourseResponseDto>> updateCourse(
             @PathVariable Long courseId,
             @RequestBody UpdateCourseRequestDto request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("강의 수정 요청: courseId={}, professorId={}", courseId, professorId);
-
-            CreateCourseResponseDto response = professorCourseService.updateCourse(courseId, request, professorId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("강의 수정 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("강의 수정 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("강의 수정 요청: courseId={}, professorId={}", courseId, professorId);
+
+        CreateCourseResponseDto response = professorCourseService.updateCourse(courseId, request, professorId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 강의 취소
      */
     @DeleteMapping("/{courseId}")
-    public ResponseEntity<?> cancelCourse(
+    public ResponseEntity<ApiResponse<Void>> cancelCourse(
             @PathVariable Long courseId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("강의 취소 요청: courseId={}, professorId={}", courseId, professorId);
-
-            professorCourseService.cancelCourse(courseId, professorId);
-            return ResponseEntity.ok(createSuccessResponse(null, "강의가 취소되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("강의 취소 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("강의 취소 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("강의 취소 요청: courseId={}, professorId={}", courseId, professorId);
+
+        professorCourseService.cancelCourse(courseId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 내가 개설한 강의 목록 조회
      */
     @GetMapping
-    public ResponseEntity<?> getMyCourses(
+    public ResponseEntity<ApiResponse<MyCoursesResponseDto>> getMyCourses(
             @RequestParam(required = false) Long academicTermId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("내 강의 목록 조회: professorId={}, academicTermId={}", professorId, academicTermId);
-
-            MyCoursesResponseDto response = professorCourseService.getMyCourses(professorId, academicTermId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("내 강의 목록 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("내 강의 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("내 강의 목록 조회: professorId={}, academicTermId={}", professorId, academicTermId);
+
+        MyCoursesResponseDto response = professorCourseService.getMyCourses(professorId, academicTermId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 교수 강의 상세 조회
      */
     @GetMapping("/{courseId}")
-    public ResponseEntity<?> getCourseDetail(
+    public ResponseEntity<ApiResponse<ProfessorCourseDetailDto>> getCourseDetail(
             @PathVariable Long courseId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            // 인증 확인
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("교수 강의 상세 조회: courseId={}, professorId={}", courseId, professorId);
-
-            ProfessorCourseDetailDto response = professorCourseService.getCourseDetail(courseId, professorId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("교수 강의 상세 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("교수 강의 상세 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
+        log.debug("교수 강의 상세 조회: courseId={}, professorId={}", courseId, professorId);
 
-    private Map<String, Object> createSuccessResponse(Object data, String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        response.put("message", message);
-        return response;
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        ProfessorCourseDetailDto response = professorCourseService.getCourseDetail(courseId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/ProfessorWeekContentController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/controller/ProfessorWeekContentController.java
@@ -1,17 +1,15 @@
 package com.mzc.backend.lms.domains.course.course.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.course.dto.UpdateWeekContentRequestDto;
 import com.mzc.backend.lms.domains.course.course.dto.WeekContentDto;
 import com.mzc.backend.lms.domains.course.course.service.CourseWeekContentService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 콘텐츠 단건(교수용) 관리 컨트롤러
@@ -29,67 +27,32 @@ public class ProfessorWeekContentController {
      * 콘텐츠 수정 (단일 contentId)
      */
     @PutMapping("/{contentId}")
-    public ResponseEntity<?> updateContent(
+    public ResponseEntity<ApiResponse<WeekContentDto>> updateContent(
             @PathVariable Long contentId,
             @RequestBody UpdateWeekContentRequestDto request,
             @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            WeekContentDto response = courseWeekContentService.updateContentByContentId(contentId, request, professorId);
-            return ResponseEntity.ok(createSuccessResponse(response, "콘텐츠가 수정되었습니다"));
-        } catch (IllegalArgumentException e) {
-            log.warn("콘텐츠 수정 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("콘텐츠 수정 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        WeekContentDto response = courseWeekContentService.updateContentByContentId(contentId, request, professorId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 콘텐츠 삭제 (단일 contentId)
      */
     @DeleteMapping("/{contentId}")
-    public ResponseEntity<?> deleteContent(
+    public ResponseEntity<ApiResponse<Void>> deleteContent(
             @PathVariable Long contentId,
             @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            courseWeekContentService.deleteContentByContentId(contentId, professorId);
-            return ResponseEntity.ok(createSuccessResponse(null, "콘텐츠가 삭제되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("콘텐츠 삭제 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("콘텐츠 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(createErrorResponse(e.getMessage()));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> createSuccessResponse(Object data, String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        response.put("message", message);
-        return response;
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        courseWeekContentService.deleteContentByContentId(contentId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/controller/ProfessorGradePublishController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/controller/ProfessorGradePublishController.java
@@ -1,16 +1,14 @@
 package com.mzc.backend.lms.domains.course.grade.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.grade.service.GradePublishService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 교수용 성적 산출/확정/공개 수동 실행 API
@@ -32,54 +30,21 @@ public class ProfessorGradePublishController {
      * - 교수 버튼(수동)용
      */
     @PostMapping("/publish-ended-terms")
-    public ResponseEntity<?> publishEndedTerms(Authentication authentication) {
-        try {
-            // 권한은 SecurityConfig에서 /api/v1/professor/** 로 제한됨
-            gradePublishService.publishEndedTerms(LocalDateTime.now());
-            return ResponseEntity.ok(success(null, "성적 공개 기간 대상 성적 공개 처리를 실행했습니다."));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("성적 수동 공개 실행 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
-        }
+    public ResponseEntity<ApiResponse<Void>> publishEndedTerms(Authentication authentication) {
+        // 권한은 SecurityConfig에서 /api/v1/professor/** 로 제한됨
+        gradePublishService.publishEndedTerms(LocalDateTime.now());
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 특정 학기의 성적 공개(수동)
      */
     @PostMapping("/publish/terms/{academicTermId}")
-    public ResponseEntity<?> publishTerm(
+    public ResponseEntity<ApiResponse<Void>> publishTerm(
             @PathVariable Long academicTermId,
             Authentication authentication
     ) {
-        try {
-            gradePublishService.publishTermIfAllowed(academicTermId, LocalDateTime.now());
-            return ResponseEntity.ok(success(null, "성적 공개 처리를 실행했습니다."));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("성적 수동 공개 실행 실패 academicTermId={}", academicTermId, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error("서버 오류"));
-        }
-    }
-
-    private Map<String, Object> success(Object data, String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        if (message != null) {
-            response.put("message", message);
-        }
-        return response;
-    }
-
-    private Map<String, Object> error(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        gradePublishService.publishTermIfAllowed(academicTermId, LocalDateTime.now());
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/controller/ProfessorGradeQueryController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/controller/ProfessorGradeQueryController.java
@@ -1,7 +1,9 @@
 package com.mzc.backend.lms.domains.course.grade.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.grade.dto.ProfessorCourseGradesResponseDto;
 import com.mzc.backend.lms.domains.course.grade.service.ProfessorGradeQueryService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,9 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -30,44 +30,23 @@ public class ProfessorGradeQueryController {
      * - status=ALL|PUBLISHED (기본 ALL)
      */
     @GetMapping("/{courseId}/grades")
-    public ResponseEntity<?> listCourseGrades(
+    public ResponseEntity<ApiResponse<List<ProfessorCourseGradesResponseDto>>> listCourseGrades(
             @PathVariable Long courseId,
             @RequestParam(required = false, defaultValue = "ALL") String status,
             @AuthenticationPrincipal Long professorId
     ) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(401).body(error("인증이 필요합니다."));
-            }
-
-            ProfessorGradeQueryService.GradeQueryStatus st;
-            try {
-                st = ProfessorGradeQueryService.GradeQueryStatus.valueOf(status);
-            } catch (Exception e) {
-                return ResponseEntity.badRequest().body(error("status는 ALL 또는 PUBLISHED 여야 합니다."));
-            }
-
-            List<ProfessorCourseGradesResponseDto> data = professorGradeQueryService.listCourseGrades(courseId, professorId, st);
-
-            Map<String, Object> res = new HashMap<>();
-            res.put("success", true);
-            res.put("data", data);
-            res.put("count", data.size());
-            return ResponseEntity.ok(res);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("교수 강의 성적 조회 실패 courseId={}, status={}", courseId, status, e);
-            return ResponseEntity.internalServerError().body(error("교수 강의 성적 조회에 실패했습니다."));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> error(String message) {
-        Map<String, Object> res = new HashMap<>();
-        res.put("success", false);
-        res.put("message", message);
-        return res;
+        ProfessorGradeQueryService.GradeQueryStatus st;
+        try {
+            st = ProfessorGradeQueryService.GradeQueryStatus.valueOf(status);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("status는 ALL 또는 PUBLISHED 여야 합니다.");
+        }
+
+        List<ProfessorCourseGradesResponseDto> data = professorGradeQueryService.listCourseGrades(courseId, professorId, st);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/controller/StudentGradeController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/controller/StudentGradeController.java
@@ -1,7 +1,9 @@
 package com.mzc.backend.lms.domains.course.grade.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.grade.dto.StudentGradeResponseDto;
 import com.mzc.backend.lms.domains.course.grade.service.StudentGradeService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,9 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -30,36 +30,15 @@ public class StudentGradeController {
      * - academicTermId로 학기 필터 가능
      */
     @GetMapping
-    public ResponseEntity<?> listMyGrades(
+    public ResponseEntity<ApiResponse<List<StudentGradeResponseDto>>> listMyGrades(
             @AuthenticationPrincipal Long studentId,
             @RequestParam(required = false) Long academicTermId
     ) {
-        try {
-            if (studentId == null) {
-                return ResponseEntity.status(401).body(error("인증이 필요합니다."));
-            }
-
-            List<StudentGradeResponseDto> data = studentGradeService.listPublishedGrades(studentId, academicTermId);
-
-            Map<String, Object> res = new HashMap<>();
-            res.put("success", true);
-            res.put("data", data);
-            res.put("count", data.size());
-            return ResponseEntity.ok(res);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(error(e.getMessage()));
-        } catch (Exception e) {
-            log.error("학생 성적 조회 실패 studentId={}, academicTermId={}", studentId, academicTermId, e);
-            return ResponseEntity.internalServerError().body(error("학생 성적 조회에 실패했습니다."));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> error(String message) {
-        Map<String, Object> res = new HashMap<>();
-        res.put("success", false);
-        res.put("message", message);
-        return res;
+        List<StudentGradeResponseDto> data = studentGradeService.listPublishedGrades(studentId, academicTermId);
+        return ResponseEntity.ok(ApiResponse.success(data));
     }
 }
-
-

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/controller/CourseNoticeController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/controller/CourseNoticeController.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.course.notice.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.course.notice.dto.request.CourseNoticeCommentRequest;
 import com.mzc.backend.lms.domains.course.notice.dto.request.CourseNoticeCreateRequest;
 import com.mzc.backend.lms.domains.course.notice.dto.request.CourseNoticeUpdateRequest;
@@ -7,6 +8,7 @@ import com.mzc.backend.lms.domains.course.notice.dto.response.CourseNoticeCommen
 import com.mzc.backend.lms.domains.course.notice.dto.response.CourseNoticeDetailResponse;
 import com.mzc.backend.lms.domains.course.notice.dto.response.CourseNoticeResponse;
 import com.mzc.backend.lms.domains.course.notice.service.CourseNoticeService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 강의 공지사항 컨트롤러
@@ -40,147 +39,92 @@ public class CourseNoticeController {
      * 공지사항 생성 (담당 교수만)
      */
     @PostMapping
-    public ResponseEntity<?> createNotice(
+    public ResponseEntity<ApiResponse<CourseNoticeResponse>> createNotice(
             @PathVariable Long courseId,
             @Valid @RequestBody CourseNoticeCreateRequest request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.info("공지사항 생성 요청: courseId={}, professorId={}", courseId, professorId);
-
-            CourseNoticeResponse response = courseNoticeService.createNotice(courseId, request, professorId);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(createSuccessResponse(response, "공지사항이 생성되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("공지사항 생성 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("공지사항 생성 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.info("공지사항 생성 요청: courseId={}, professorId={}", courseId, professorId);
+
+        CourseNoticeResponse response = courseNoticeService.createNotice(courseId, request, professorId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     /**
      * 공지사항 목록 조회 (수강생 + 담당 교수)
      */
     @GetMapping
-    public ResponseEntity<?> getNotices(
+    public ResponseEntity<ApiResponse<Page<CourseNoticeResponse>>> getNotices(
             @PathVariable Long courseId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal Long userId) {
-        try {
-            if (userId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("공지사항 목록 조회: courseId={}, userId={}", courseId, userId);
-
-            Page<CourseNoticeResponse> response = courseNoticeService.getNotices(courseId, userId, pageable);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("공지사항 목록 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("공지사항 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (userId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("공지사항 목록 조회: courseId={}, userId={}", courseId, userId);
+
+        Page<CourseNoticeResponse> response = courseNoticeService.getNotices(courseId, userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 공지사항 상세 조회 (수강생 + 담당 교수)
      */
     @GetMapping("/{noticeId}")
-    public ResponseEntity<?> getNotice(
+    public ResponseEntity<ApiResponse<CourseNoticeDetailResponse>> getNotice(
             @PathVariable Long courseId,
             @PathVariable Long noticeId,
             @AuthenticationPrincipal Long userId) {
-        try {
-            if (userId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("공지사항 상세 조회: courseId={}, noticeId={}, userId={}", courseId, noticeId, userId);
-
-            CourseNoticeDetailResponse response = courseNoticeService.getNotice(courseId, noticeId, userId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("공지사항 상세 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("공지사항 상세 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (userId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("공지사항 상세 조회: courseId={}, noticeId={}, userId={}", courseId, noticeId, userId);
+
+        CourseNoticeDetailResponse response = courseNoticeService.getNotice(courseId, noticeId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 공지사항 수정 (담당 교수만)
      */
     @PutMapping("/{noticeId}")
-    public ResponseEntity<?> updateNotice(
+    public ResponseEntity<ApiResponse<CourseNoticeResponse>> updateNotice(
             @PathVariable Long courseId,
             @PathVariable Long noticeId,
             @Valid @RequestBody CourseNoticeUpdateRequest request,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.info("공지사항 수정 요청: courseId={}, noticeId={}, professorId={}", courseId, noticeId, professorId);
-
-            CourseNoticeResponse response = courseNoticeService.updateNotice(courseId, noticeId, request, professorId);
-            return ResponseEntity.ok(createSuccessResponse(response, "공지사항이 수정되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("공지사항 수정 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("공지사항 수정 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.info("공지사항 수정 요청: courseId={}, noticeId={}, professorId={}", courseId, noticeId, professorId);
+
+        CourseNoticeResponse response = courseNoticeService.updateNotice(courseId, noticeId, request, professorId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 공지사항 삭제 (담당 교수만)
      */
     @DeleteMapping("/{noticeId}")
-    public ResponseEntity<?> deleteNotice(
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(
             @PathVariable Long courseId,
             @PathVariable Long noticeId,
             @AuthenticationPrincipal Long professorId) {
-        try {
-            if (professorId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.info("공지사항 삭제 요청: courseId={}, noticeId={}, professorId={}", courseId, noticeId, professorId);
-
-            courseNoticeService.deleteNotice(courseId, noticeId, professorId);
-            return ResponseEntity.ok(createSuccessResponse(null, "공지사항이 삭제되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("공지사항 삭제 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("공지사항 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (professorId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.info("공지사항 삭제 요청: courseId={}, noticeId={}, professorId={}", courseId, noticeId, professorId);
+
+        courseNoticeService.deleteNotice(courseId, noticeId, professorId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     // === 댓글 API ===
@@ -189,150 +133,82 @@ public class CourseNoticeController {
      * 댓글 작성 (수강생 + 담당 교수)
      */
     @PostMapping("/{noticeId}/comments")
-    public ResponseEntity<?> createComment(
+    public ResponseEntity<ApiResponse<CourseNoticeCommentResponse>> createComment(
             @PathVariable Long courseId,
             @PathVariable Long noticeId,
             @Valid @RequestBody CourseNoticeCommentRequest request,
             @AuthenticationPrincipal Long userId) {
-        try {
-            if (userId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.info("댓글 작성 요청: courseId={}, noticeId={}, userId={}", courseId, noticeId, userId);
-
-            CourseNoticeCommentResponse response = courseNoticeService.createComment(courseId, noticeId, request, userId);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(createSuccessResponse(response, "댓글이 작성되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("댓글 작성 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("댓글 작성 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (userId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.info("댓글 작성 요청: courseId={}, noticeId={}, userId={}", courseId, noticeId, userId);
+
+        CourseNoticeCommentResponse response = courseNoticeService.createComment(courseId, noticeId, request, userId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     /**
      * 대댓글 작성 (수강생 + 담당 교수)
      */
     @PostMapping("/{noticeId}/comments/{parentId}/replies")
-    public ResponseEntity<?> createReply(
+    public ResponseEntity<ApiResponse<CourseNoticeCommentResponse>> createReply(
             @PathVariable Long courseId,
             @PathVariable Long noticeId,
             @PathVariable Long parentId,
             @Valid @RequestBody CourseNoticeCommentRequest request,
             @AuthenticationPrincipal Long userId) {
-        try {
-            if (userId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.info("대댓글 작성 요청: courseId={}, noticeId={}, parentId={}, userId={}",
-                    courseId, noticeId, parentId, userId);
-
-            CourseNoticeCommentResponse response = courseNoticeService.createReply(courseId, noticeId, parentId, request, userId);
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(createSuccessResponse(response, "답글이 작성되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("대댓글 작성 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("대댓글 작성 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (userId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.info("대댓글 작성 요청: courseId={}, noticeId={}, parentId={}, userId={}",
+                courseId, noticeId, parentId, userId);
+
+        CourseNoticeCommentResponse response = courseNoticeService.createReply(courseId, noticeId, parentId, request, userId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
     }
 
     /**
      * 댓글 수정 (작성자만)
      */
     @PutMapping("/{noticeId}/comments/{commentId}")
-    public ResponseEntity<?> updateComment(
+    public ResponseEntity<ApiResponse<CourseNoticeCommentResponse>> updateComment(
             @PathVariable Long courseId,
             @PathVariable Long noticeId,
             @PathVariable Long commentId,
             @Valid @RequestBody CourseNoticeCommentRequest request,
             @AuthenticationPrincipal Long userId) {
-        try {
-            if (userId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.info("댓글 수정 요청: courseId={}, noticeId={}, commentId={}, userId={}",
-                    courseId, noticeId, commentId, userId);
-
-            CourseNoticeCommentResponse response = courseNoticeService.updateComment(courseId, noticeId, commentId, request, userId);
-            return ResponseEntity.ok(createSuccessResponse(response, "댓글이 수정되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("댓글 수정 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("댓글 수정 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (userId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.info("댓글 수정 요청: courseId={}, noticeId={}, commentId={}, userId={}",
+                courseId, noticeId, commentId, userId);
+
+        CourseNoticeCommentResponse response = courseNoticeService.updateComment(courseId, noticeId, commentId, request, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 댓글 삭제 (작성자만)
      */
     @DeleteMapping("/{noticeId}/comments/{commentId}")
-    public ResponseEntity<?> deleteComment(
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
             @PathVariable Long courseId,
             @PathVariable Long noticeId,
             @PathVariable Long commentId,
             @AuthenticationPrincipal Long userId) {
-        try {
-            if (userId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.info("댓글 삭제 요청: courseId={}, noticeId={}, commentId={}, userId={}",
-                    courseId, noticeId, commentId, userId);
-
-            courseNoticeService.deleteComment(courseId, noticeId, commentId, userId);
-            return ResponseEntity.ok(createSuccessResponse(null, "댓글이 삭제되었습니다."));
-        } catch (IllegalArgumentException e) {
-            log.warn("댓글 삭제 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("댓글 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse("서버 오류가 발생했습니다."));
+        if (userId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    // === Response Helper Methods ===
+        log.info("댓글 삭제 요청: courseId={}, noticeId={}, commentId={}, userId={}",
+                courseId, noticeId, commentId, userId);
 
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
-
-    private Map<String, Object> createSuccessResponse(Object data, String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        response.put("message", message);
-        return response;
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        courseNoticeService.deleteComment(courseId, noticeId, commentId, userId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/controller/StudentDashboardController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/dashboard/student/controller/StudentDashboardController.java
@@ -1,10 +1,12 @@
 package com.mzc.backend.lms.domains.dashboard.student.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.dashboard.student.dto.EnrollmentSummaryDto;
 import com.mzc.backend.lms.domains.dashboard.student.dto.NoticeDto;
 import com.mzc.backend.lms.domains.dashboard.student.dto.PendingAssignmentDto;
 import com.mzc.backend.lms.domains.dashboard.student.dto.TodayCourseDto;
 import com.mzc.backend.lms.domains.dashboard.student.service.StudentDashboardService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -14,9 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * 학생 대시보드 컨트롤러
@@ -39,29 +39,16 @@ public class StudentDashboardController {
      * @return 미제출 과제 목록
      */
     @GetMapping("/pending-assignments")
-    public ResponseEntity<?> getPendingAssignments(
+    public ResponseEntity<ApiResponse<List<PendingAssignmentDto>>> getPendingAssignments(
             @AuthenticationPrincipal Long studentId,
             @RequestParam(defaultValue = "7") int days) {
-        try {
-            validateStudentId(studentId);
-            int validDays = validateDays(days);
-
-            List<PendingAssignmentDto> assignments =
-                    studentDashboardService.getPendingAssignments(studentId, validDays);
-
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("data", assignments);
-            response.put("count", assignments.size());
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("미제출 과제 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("미제출 과제 목록 조회에 실패했습니다."));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+        int validDays = validateDays(days);
+        List<PendingAssignmentDto> assignments =
+                studentDashboardService.getPendingAssignments(studentId, validDays);
+        return ResponseEntity.ok(ApiResponse.success(assignments));
     }
 
     /**
@@ -71,25 +58,13 @@ public class StudentDashboardController {
      * @return 오늘의 강의 목록
      */
     @GetMapping("/today-courses")
-    public ResponseEntity<?> getTodayCourses(@AuthenticationPrincipal Long studentId) {
-        try {
-            validateStudentId(studentId);
-
-            List<TodayCourseDto> courses = studentDashboardService.getTodayCourses(studentId);
-
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("data", courses);
-            response.put("count", courses.size());
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("오늘의 강의 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("오늘의 강의 목록 조회에 실패했습니다."));
+    public ResponseEntity<ApiResponse<List<TodayCourseDto>>> getTodayCourses(
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+        List<TodayCourseDto> courses = studentDashboardService.getTodayCourses(studentId);
+        return ResponseEntity.ok(ApiResponse.success(courses));
     }
 
     /**
@@ -99,24 +74,11 @@ public class StudentDashboardController {
      * @return 최신 공지사항 목록
      */
     @GetMapping("/notices")
-    public ResponseEntity<?> getLatestNotices(
+    public ResponseEntity<ApiResponse<List<NoticeDto>>> getLatestNotices(
             @RequestParam(defaultValue = "5") int limit) {
-        try {
-            int validLimit = Math.min(Math.max(limit, 1), 10);
-
-            List<NoticeDto> notices = studentDashboardService.getLatestNotices(validLimit);
-
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("data", notices);
-            response.put("count", notices.size());
-
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            log.error("공지사항 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("공지사항 목록 조회에 실패했습니다."));
-        }
+        int validLimit = Math.min(Math.max(limit, 1), 10);
+        List<NoticeDto> notices = studentDashboardService.getLatestNotices(validLimit);
+        return ResponseEntity.ok(ApiResponse.success(notices));
     }
 
     /**
@@ -126,40 +88,16 @@ public class StudentDashboardController {
      * @return 수강 중인 과목 수와 총 학점
      */
     @GetMapping("/enrollment-summary")
-    public ResponseEntity<?> getEnrollmentSummary(@AuthenticationPrincipal Long studentId) {
-        try {
-            validateStudentId(studentId);
-
-            EnrollmentSummaryDto summary = studentDashboardService.getEnrollmentSummary(studentId);
-
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("data", summary);
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("수강 현황 요약 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("수강 현황 요약 조회에 실패했습니다."));
-        }
-    }
-
-    private void validateStudentId(Long studentId) {
+    public ResponseEntity<ApiResponse<EnrollmentSummaryDto>> getEnrollmentSummary(
+            @AuthenticationPrincipal Long studentId) {
         if (studentId == null) {
-            throw new IllegalArgumentException("인증이 필요합니다.");
+            throw AuthException.unauthorized();
         }
+        EnrollmentSummaryDto summary = studentDashboardService.getEnrollmentSummary(studentId);
+        return ResponseEntity.ok(ApiResponse.success(summary));
     }
 
     private int validateDays(int days) {
         return Math.min(Math.max(days, 1), MAX_DAYS);
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/controller/CartController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/controller/CartController.java
@@ -1,20 +1,18 @@
 package com.mzc.backend.lms.domains.enrollment.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.enrollment.dto.CourseIdsRequestDto;
 import com.mzc.backend.lms.domains.enrollment.dto.CartBulkAddResponseDto;
 import com.mzc.backend.lms.domains.enrollment.dto.CartBulkDeleteRequestDto;
 import com.mzc.backend.lms.domains.enrollment.dto.CartBulkDeleteResponseDto;
 import com.mzc.backend.lms.domains.enrollment.dto.CartResponseDto;
 import com.mzc.backend.lms.domains.enrollment.service.CartService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 장바구니 컨트롤러
@@ -31,126 +29,65 @@ public class CartController {
      * 장바구니 조회
      */
     @GetMapping
-    public ResponseEntity<?> getCart(@AuthenticationPrincipal Long studentId) {
-        try {
-            // 인증 확인
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("장바구니 조회: studentId={}", studentId);
-
-            CartResponseDto response = cartService.getCart(String.valueOf(studentId));
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (Exception e) {
-            log.error("장바구니 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+    public ResponseEntity<ApiResponse<CartResponseDto>> getCart(
+            @AuthenticationPrincipal Long studentId) {
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("장바구니 조회: studentId={}", studentId);
+
+        CartResponseDto response = cartService.getCart(String.valueOf(studentId));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 장바구니에 강의 요청 항목 일괄 추가
      */
     @PostMapping("/bulk")
-    public ResponseEntity<?> addToCartBulk(
+    public ResponseEntity<ApiResponse<CartBulkAddResponseDto>> addToCartBulk(
             @RequestBody CourseIdsRequestDto request,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            // 인증 확인
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("장바구니 요청 항목 일괄 추가: studentId={}, courseIds={}", studentId, request.getCourseIds());
-
-            CartBulkAddResponseDto response = cartService.addToCartBulk(request, String.valueOf(studentId));
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("장바구니 요청 항목 일괄 추가 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("장바구니 요청 항목 일괄 추가 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("장바구니 요청 항목 일괄 추가: studentId={}, courseIds={}", studentId, request.getCourseIds());
+
+        CartBulkAddResponseDto response = cartService.addToCartBulk(request, String.valueOf(studentId));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 장바구니에서 강의 요청 항목 일괄 삭제
      */
     @DeleteMapping("/bulk")
-    public ResponseEntity<?> deleteFromCartBulk(
+    public ResponseEntity<ApiResponse<CartBulkDeleteResponseDto>> deleteFromCartBulk(
             @RequestBody CartBulkDeleteRequestDto request,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            // 인증 확인
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("장바구니 요청 항목 일괄 삭제: studentId={}, cartIds={}", studentId, request.getCartIds());
-
-            CartBulkDeleteResponseDto response = cartService.deleteFromCartBulk(request, String.valueOf(studentId));
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("장바구니 요청 항목 일괄 삭제 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("장바구니 요청 항목 일괄 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("장바구니 요청 항목 일괄 삭제: studentId={}, cartIds={}", studentId, request.getCartIds());
+
+        CartBulkDeleteResponseDto response = cartService.deleteFromCartBulk(request, String.valueOf(studentId));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 장바구니 전체 비우기
      */
-
     @DeleteMapping
-    public ResponseEntity<?> deleteAllCart(
+    public ResponseEntity<ApiResponse<CartBulkDeleteResponseDto>> deleteAllCart(
             @AuthenticationPrincipal Long studentId) {
-        try {
-            // 인증 확인
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("장바구니 전체 비우기: studentId={}", studentId);
-
-            CartBulkDeleteResponseDto response = cartService.deleteAllCart(String.valueOf(studentId));
-            return ResponseEntity.ok(createSuccessResponse(response));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
-        catch (IllegalArgumentException e) {
-            log.warn("장바구니 전체 비우기 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        }
-        catch (Exception e) {
-            log.error("장바구니 전체 비우기 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
-        }
-    }
 
+        log.debug("장바구니 전체 비우기: studentId={}", studentId);
 
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
-
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        CartBulkDeleteResponseDto response = cartService.deleteAllCart(String.valueOf(studentId));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/controller/EnrollmentController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/controller/EnrollmentController.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.enrollment.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.enrollment.dto.CourseIdsRequestDto;
 import com.mzc.backend.lms.domains.enrollment.dto.CourseListResponseDto;
 import com.mzc.backend.lms.domains.enrollment.dto.CourseSearchRequestDto;
@@ -11,15 +12,12 @@ import com.mzc.backend.lms.domains.enrollment.dto.MyEnrollmentsResponseDto;
 import com.mzc.backend.lms.domains.enrollment.service.EnrollmentCourseService;
 import com.mzc.backend.lms.domains.enrollment.service.EnrollmentPeriodService;
 import com.mzc.backend.lms.domains.enrollment.service.EnrollmentService;
+import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 수강신청 컨트롤러
@@ -36,31 +34,19 @@ public class EnrollmentController {
 
     /**
      * 현재 활성화된 기간 조회
-     * @param type 기간 타입 코드 (ENROLLMENT, COURSE_REGISTRATION, ADJUSTMENT, CANCELLATION)
-     *             기본값: ENROLLMENT
      */
     @GetMapping("/periods/current")
-    public ResponseEntity<?> getCurrentPeriod(
+    public ResponseEntity<ApiResponse<EnrollmentPeriodResponseDto>> getCurrentPeriod(
             @RequestParam(required = false) String type) {
-        try {
-            EnrollmentPeriodResponseDto response = enrollmentPeriodService.getCurrentPeriod(type);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("기간 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("기간 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
-        }
+        EnrollmentPeriodResponseDto response = enrollmentPeriodService.getCurrentPeriod(type);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 강의 목록 조회 (검색 및 필터링)
      */
     @GetMapping("/courses")
-    public ResponseEntity<?> searchCourses(
+    public ResponseEntity<ApiResponse<CourseListResponseDto>> searchCourses(
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size,
             @RequestParam(required = false) String keyword,
@@ -70,152 +56,78 @@ public class EnrollmentController {
             @RequestParam(required = true) Long enrollmentPeriodId,
             @RequestParam(required = false) String sort,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-            
-            // 디버깅: 파라미터 확인
-            log.debug("검색 파라미터: keyword={}, departmentId={}, courseType={}, credits={}, enrollmentPeriodId={}", 
-                    keyword, departmentId, courseType, credits, enrollmentPeriodId);
-            
-            CourseSearchRequestDto request = CourseSearchRequestDto.builder()
-                    .page(page)
-                    .size(size)
-                    .keyword(keyword)
-                    .departmentId(departmentId)
-                    .courseType(courseType)
-                    .credits(credits)
-                    .enrollmentPeriodId(enrollmentPeriodId)
-                    .sort(sort)
-                    .build();
-
-            CourseListResponseDto response = enrollmentCourseService.searchCourses(request, String.valueOf(studentId));
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (Exception e) {
-            log.error("강의 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("검색 파라미터: keyword={}, departmentId={}, courseType={}, credits={}, enrollmentPeriodId={}",
+                keyword, departmentId, courseType, credits, enrollmentPeriodId);
+
+        CourseSearchRequestDto request = CourseSearchRequestDto.builder()
+                .page(page)
+                .size(size)
+                .keyword(keyword)
+                .departmentId(departmentId)
+                .courseType(courseType)
+                .credits(credits)
+                .enrollmentPeriodId(enrollmentPeriodId)
+                .sort(sort)
+                .build();
+
+        CourseListResponseDto response = enrollmentCourseService.searchCourses(request, String.valueOf(studentId));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 일괄 수강신청
      */
     @PostMapping("/bulk")
-    public ResponseEntity<?> enrollBulk(
+    public ResponseEntity<ApiResponse<EnrollmentBulkResponseDto>> enrollBulk(
             @RequestBody CourseIdsRequestDto request,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            // 인증 확인
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("일괄 수강신청: studentId={}, courseIds={}", studentId, request.getCourseIds());
-
-            EnrollmentBulkResponseDto response = enrollmentService.enrollBulk(request, String.valueOf(studentId));
-            
-            // 메시지 생성 - totalAttempted 포함
-            String message = String.format("%d개 과목 수강신청 완료", response.getSummary().getSuccessCount());
-            if (response.getSummary().getFailedCount() > 0) {
-                message += String.format(", %d개 과목 실패", response.getSummary().getFailedCount());
-            }
-
-            Map<String, Object> successResponse = createSuccessResponse(response);
-            successResponse.put("message", message);
-            return ResponseEntity.ok(successResponse);
-        } catch (IllegalArgumentException e) {
-            log.warn("일괄 수강신청 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("일괄 수강신청 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("일괄 수강신청: studentId={}, courseIds={}", studentId, request.getCourseIds());
+
+        EnrollmentBulkResponseDto response = enrollmentService.enrollBulk(request, String.valueOf(studentId));
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 일괄 수강신청 취소
      */
     @DeleteMapping("/bulk")
-    public ResponseEntity<?> cancelBulk(
+    public ResponseEntity<ApiResponse<EnrollmentBulkCancelResponseDto>> cancelBulk(
             @RequestBody EnrollmentBulkCancelRequestDto request,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            // 인증 확인
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("일괄 수강신청 취소: studentId={}, enrollmentIds={}", studentId, request.getEnrollmentIds());
-
-            EnrollmentBulkCancelResponseDto response = enrollmentService.cancelBulk(request, String.valueOf(studentId));
-            
-            // 메시지 생성
-            String message = String.format("%d개 과목 취소 완료", response.getSummary().getSuccessCount());
-            if (response.getSummary().getFailedCount() > 0) {
-                message += String.format(", %d개 과목 실패", response.getSummary().getFailedCount());
-            }
-
-            Map<String, Object> successResponse = createSuccessResponse(response);
-            successResponse.put("message", message);
-            return ResponseEntity.ok(successResponse);
-        } catch (IllegalArgumentException e) {
-            log.warn("일괄 수강신청 취소 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("일괄 수강신청 취소 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
+
+        log.debug("일괄 수강신청 취소: studentId={}, enrollmentIds={}", studentId, request.getEnrollmentIds());
+
+        EnrollmentBulkCancelResponseDto response = enrollmentService.cancelBulk(request, String.valueOf(studentId));
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 내 수강신청 목록 조회
      */
     @GetMapping("/my")
-    public ResponseEntity<?> getMyEnrollments(
+    public ResponseEntity<ApiResponse<MyEnrollmentsResponseDto>> getMyEnrollments(
             @RequestParam(required = false) Long enrollmentPeriodId,
             @AuthenticationPrincipal Long studentId) {
-        try {
-            // 인증 확인
-            if (studentId == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(createErrorResponse("로그인이 필요합니다."));
-            }
-
-            log.debug("내 수강신청 목록 조회: studentId={}, enrollmentPeriodId={}", studentId, enrollmentPeriodId);
-
-            MyEnrollmentsResponseDto response = enrollmentService.getMyEnrollments(String.valueOf(studentId), enrollmentPeriodId);
-            return ResponseEntity.ok(createSuccessResponse(response));
-        } catch (IllegalArgumentException e) {
-            log.warn("내 수강신청 목록 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("내 수강신청 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(createErrorResponse(e.getMessage()));
+        if (studentId == null) {
+            throw AuthException.unauthorized();
         }
-    }
 
-    private Map<String, Object> createSuccessResponse(Object data) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("data", data);
-        return response;
-    }
+        log.debug("내 수강신청 목록 조회: studentId={}, enrollmentPeriodId={}", studentId, enrollmentPeriodId);
 
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
+        MyEnrollmentsResponseDto response = enrollmentService.getMyEnrollments(String.valueOf(studentId), enrollmentPeriodId);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/notification/controller/NotificationController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/notification/controller/NotificationController.java
@@ -1,7 +1,11 @@
 package com.mzc.backend.lms.domains.notification.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
+import com.mzc.backend.lms.domains.notification.dto.BulkDeleteResponseDto;
+import com.mzc.backend.lms.domains.notification.dto.BulkUpdateResponseDto;
 import com.mzc.backend.lms.domains.notification.dto.NotificationCursorResponseDto;
 import com.mzc.backend.lms.domains.notification.dto.NotificationResponseDto;
+import com.mzc.backend.lms.domains.notification.dto.UnreadCountResponseDto;
 import com.mzc.backend.lms.domains.notification.service.NotificationService;
 import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 알림 컨트롤러
@@ -30,229 +31,130 @@ public class NotificationController {
 
     /**
      * 알림 목록 조회 (커서 기반)
-     *
-     * @param cursor 커서 (이전 응답의 nextCursor, 첫 요청 시 생략)
-     * @param size 페이지 크기 (기본값: 20, 최대: 100)
-     * @param unreadOnly 읽지 않은 알림만 조회 여부
      */
     @GetMapping
-    public ResponseEntity<?> getNotifications(
+    public ResponseEntity<ApiResponse<NotificationCursorResponseDto>> getNotifications(
             @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "false") boolean unreadOnly) {
-        try {
-            validateUserId(userId);
-            int validSize = validateSize(size);
+        validateUserId(userId);
+        int validSize = validateSize(size);
 
-            NotificationCursorResponseDto response;
-            if (unreadOnly) {
-                response = notificationService.getUnreadNotifications(userId, cursor, validSize);
-            } else {
-                response = notificationService.getNotifications(userId, cursor, validSize);
-            }
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("알림 목록 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("알림 목록 조회에 실패했습니다."));
+        NotificationCursorResponseDto response;
+        if (unreadOnly) {
+            response = notificationService.getUnreadNotifications(userId, cursor, validSize);
+        } else {
+            response = notificationService.getNotifications(userId, cursor, validSize);
         }
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 알림 상세 조회
      */
     @GetMapping("/{notificationId}")
-    public ResponseEntity<?> getNotification(
+    public ResponseEntity<ApiResponse<NotificationResponseDto>> getNotification(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long notificationId) {
-        try {
-            validateUserId(userId);
+        validateUserId(userId);
 
-            NotificationResponseDto response = notificationService.getNotification(userId, notificationId);
+        NotificationResponseDto response = notificationService.getNotification(userId, notificationId);
 
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("알림 상세 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("알림 조회에 실패했습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 읽지 않은 알림 개수 조회
      */
     @GetMapping("/unread-count")
-    public ResponseEntity<?> getUnreadCount(@AuthenticationPrincipal Long userId) {
-        try {
-            validateUserId(userId);
+    public ResponseEntity<ApiResponse<UnreadCountResponseDto>> getUnreadCount(
+            @AuthenticationPrincipal Long userId) {
+        validateUserId(userId);
 
-            long unreadCount = notificationService.getUnreadCount(userId);
+        long unreadCount = notificationService.getUnreadCount(userId);
 
-            Map<String, Object> response = new HashMap<>();
-            response.put("unreadCount", unreadCount);
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("읽지 않은 알림 개수 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("알림 개수 조회에 실패했습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.success(new UnreadCountResponseDto(unreadCount)));
     }
 
     /**
      * 알림 읽음 처리
      */
     @PatchMapping("/{notificationId}/read")
-    public ResponseEntity<?> markAsRead(
+    public ResponseEntity<ApiResponse<NotificationResponseDto>> markAsRead(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long notificationId) {
-        try {
-            validateUserId(userId);
+        validateUserId(userId);
 
-            NotificationResponseDto response = notificationService.markAsRead(userId, notificationId);
+        NotificationResponseDto response = notificationService.markAsRead(userId, notificationId);
 
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("알림 읽음 처리 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("알림 읽음 처리에 실패했습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 모든 알림 읽음 처리
      */
     @PatchMapping("/read-all")
-    public ResponseEntity<?> markAllAsRead(@AuthenticationPrincipal Long userId) {
-        try {
-            validateUserId(userId);
+    public ResponseEntity<ApiResponse<BulkUpdateResponseDto>> markAllAsRead(
+            @AuthenticationPrincipal Long userId) {
+        validateUserId(userId);
 
-            int updatedCount = notificationService.markAllAsRead(userId);
+        int updatedCount = notificationService.markAllAsRead(userId);
 
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("message", "모든 알림이 읽음 처리되었습니다.");
-            response.put("updatedCount", updatedCount);
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("모든 알림 읽음 처리 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("알림 읽음 처리에 실패했습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.success(
+                new BulkUpdateResponseDto("모든 알림이 읽음 처리되었습니다.", updatedCount)));
     }
 
     /**
      * 알림 삭제
      */
     @DeleteMapping("/{notificationId}")
-    public ResponseEntity<?> deleteNotification(
+    public ResponseEntity<ApiResponse<ApiResponse.MessageResponse>> deleteNotification(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long notificationId) {
-        try {
-            validateUserId(userId);
+        validateUserId(userId);
 
-            notificationService.deleteNotification(userId, notificationId);
+        notificationService.deleteNotification(userId, notificationId);
 
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("message", "알림이 삭제되었습니다.");
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("알림 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("알림 삭제에 실패했습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.successMessage("알림이 삭제되었습니다."));
     }
 
     /**
      * 읽은 알림 일괄 삭제 (벌크 삭제)
      */
     @DeleteMapping("/read")
-    public ResponseEntity<?> deleteReadNotifications(@AuthenticationPrincipal Long userId) {
-        try {
-            validateUserId(userId);
+    public ResponseEntity<ApiResponse<BulkDeleteResponseDto>> deleteReadNotifications(
+            @AuthenticationPrincipal Long userId) {
+        validateUserId(userId);
 
-            int deletedCount = notificationService.deleteReadNotifications(userId);
+        int deletedCount = notificationService.deleteReadNotifications(userId);
 
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("message", "읽은 알림이 삭제되었습니다.");
-            response.put("deletedCount", deletedCount);
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("읽은 알림 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("읽은 알림 삭제에 실패했습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.success(
+                new BulkDeleteResponseDto("읽은 알림이 삭제되었습니다.", deletedCount)));
     }
 
     /**
      * 모든 알림 삭제 (벌크 삭제)
      */
     @DeleteMapping("/all")
-    public ResponseEntity<?> deleteAllNotifications(@AuthenticationPrincipal Long userId) {
-        try {
-            validateUserId(userId);
+    public ResponseEntity<ApiResponse<BulkDeleteResponseDto>> deleteAllNotifications(
+            @AuthenticationPrincipal Long userId) {
+        validateUserId(userId);
 
-            int deletedCount = notificationService.deleteAllNotifications(userId);
+        int deletedCount = notificationService.deleteAllNotifications(userId);
 
-            Map<String, Object> response = new HashMap<>();
-            response.put("success", true);
-            response.put("message", "모든 알림이 삭제되었습니다.");
-            response.put("deletedCount", deletedCount);
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(createErrorResponse(e.getMessage()));
-        } catch (Exception e) {
-            log.error("모든 알림 삭제 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError()
-                    .body(createErrorResponse("모든 알림 삭제에 실패했습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.success(
+                new BulkDeleteResponseDto("모든 알림이 삭제되었습니다.", deletedCount)));
     }
 
-    /**
-     * 사용자 ID 유효성 검증
-     */
     private void validateUserId(Long userId) {
         if (userId == null) {
-            throw AuthException.invalidToken();
+            throw AuthException.unauthorized();
         }
     }
 
-    /**
-     * 페이지 크기 유효성 검증
-     */
     private int validateSize(int size) {
         return Math.min(Math.max(size, 1), MAX_SIZE);
-    }
-
-    /**
-     * 에러 응답 생성
-     */
-    private Map<String, Object> createErrorResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", false);
-        response.put("message", message);
-        return response;
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/notification/dto/BulkDeleteResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/notification/dto/BulkDeleteResponseDto.java
@@ -1,0 +1,6 @@
+package com.mzc.backend.lms.domains.notification.dto;
+
+/**
+ * 일괄 삭제 응답 DTO
+ */
+public record BulkDeleteResponseDto(String message, int deletedCount) {}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/notification/dto/BulkUpdateResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/notification/dto/BulkUpdateResponseDto.java
@@ -1,0 +1,6 @@
+package com.mzc.backend.lms.domains.notification.dto;
+
+/**
+ * 일괄 업데이트 응답 DTO
+ */
+public record BulkUpdateResponseDto(String message, int updatedCount) {}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/notification/dto/UnreadCountResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/notification/dto/UnreadCountResponseDto.java
@@ -1,0 +1,6 @@
+package com.mzc.backend.lms.domains.notification.dto;
+
+/**
+ * 읽지 않은 알림 개수 응답 DTO
+ */
+public record UnreadCountResponseDto(long unreadCount) {}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/controller/AuthController.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.user.auth.controller;
 
+import com.mzc.backend.lms.common.response.ApiResponse;
 import com.mzc.backend.lms.domains.user.auth.dto.*;
 import com.mzc.backend.lms.domains.user.auth.email.service.EmailVerificationService;
 import com.mzc.backend.lms.domains.user.auth.exception.AuthException;
@@ -12,9 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 인증 컨트롤러
@@ -30,81 +28,86 @@ public class AuthController implements AuthControllerSwagger {
 
     @Override
     @PostMapping("/signup/email-verification")
-    public ResponseEntity<?> sendVerificationCode(@Valid @RequestBody EmailVerificationRequestDto dto) {
+    public ResponseEntity<ApiResponse<ApiResponse.MessageResponse>> sendVerificationCode(
+            @Valid @RequestBody EmailVerificationRequestDto dto) {
         if (!authService.isEmailAvailable(dto.getEmail())) {
             throw AuthException.emailAlreadyExists(dto.getEmail());
         }
 
         emailVerificationService.sendVerificationCode(dto.getEmail());
 
-        return ResponseEntity.ok(createSuccessResponse("인증 코드가 발송되었습니다."));
+        return ResponseEntity.ok(ApiResponse.successMessage("인증 코드가 발송되었습니다."));
     }
 
     @Override
     @PostMapping("/signup/verify-code")
-    public ResponseEntity<?> verifyCode(@Valid @RequestBody VerifyCodeRequestDto dto) {
+    public ResponseEntity<ApiResponse<ApiResponse.MessageResponse>> verifyCode(
+            @Valid @RequestBody VerifyCodeRequestDto dto) {
         boolean verified = emailVerificationService.verifyCode(dto.getEmail(), dto.getCode());
 
         if (!verified) {
             throw AuthException.emailVerificationFailed();
         }
 
-        return ResponseEntity.ok(createSuccessResponse("이메일 인증이 완료되었습니다."));
+        return ResponseEntity.ok(ApiResponse.successMessage("이메일 인증이 완료되었습니다."));
     }
 
     @Override
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@Valid @RequestBody SignupRequestDto dto) {
+    public ResponseEntity<ApiResponse<SignupResponseDto>> signup(
+            @Valid @RequestBody SignupRequestDto dto) {
         String userId = authService.signup(dto);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("message", "회원가입이 완료되었습니다.");
-        response.put("userId", userId);
+        SignupResponseDto response = new SignupResponseDto(userId, "회원가입이 완료되었습니다.");
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
     @Override
     @PostMapping("/login")
-    public ResponseEntity<?> login(@Valid @RequestBody LoginRequestDto dto,
-                                  HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponseDto>> login(
+            @Valid @RequestBody LoginRequestDto dto,
+            HttpServletRequest request) {
         String ipAddress = getClientIpAddress(request);
         dto.setIpAddress(ipAddress);
 
         LoginResponseDto response = authService.login(dto, ipAddress);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Override
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshToken(@Valid @RequestBody RefreshTokenRequestDto dto) {
+    public ResponseEntity<ApiResponse<RefreshTokenResponseDto>> refreshToken(
+            @Valid @RequestBody RefreshTokenRequestDto dto) {
         RefreshTokenResponseDto response = authService.refreshToken(dto);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Override
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestHeader(value = "Refresh-Token", required = false) String refreshToken) {
+    public ResponseEntity<ApiResponse<ApiResponse.MessageResponse>> logout(
+            @RequestHeader(value = "Refresh-Token", required = false) String refreshToken) {
         if (refreshToken != null && !refreshToken.isEmpty()) {
             authService.logout(refreshToken);
         }
 
-        return ResponseEntity.ok(createSuccessResponse("로그아웃되었습니다."));
+        return ResponseEntity.ok(ApiResponse.successMessage("로그아웃되었습니다."));
     }
 
     @Override
     @GetMapping("/check-email")
-    public ResponseEntity<?> checkEmailAvailability(@RequestParam String email) {
+    public ResponseEntity<ApiResponse<EmailAvailabilityResponseDto>> checkEmailAvailability(
+            @RequestParam String email) {
         boolean available = authService.isEmailAvailable(email);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("available", available);
-        response.put("message", available ? "사용 가능한 이메일입니다." : "이미 사용 중인 이메일입니다.");
+        EmailAvailabilityResponseDto response = new EmailAvailabilityResponseDto(
+                available,
+                available ? "사용 가능한 이메일입니다." : "이미 사용 중인 이메일입니다."
+        );
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
@@ -131,15 +134,5 @@ public class AuthController implements AuthControllerSwagger {
         }
 
         return request.getRemoteAddr();
-    }
-
-    /**
-     * 성공 응답 생성
-     */
-    private Map<String, Object> createSuccessResponse(String message) {
-        Map<String, Object> response = new HashMap<>();
-        response.put("success", true);
-        response.put("message", message);
-        return response;
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/dto/EmailAvailabilityResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/dto/EmailAvailabilityResponseDto.java
@@ -1,0 +1,9 @@
+package com.mzc.backend.lms.domains.user.auth.dto;
+
+/**
+ * 이메일 가용성 확인 응답 DTO
+ */
+public record EmailAvailabilityResponseDto(
+        boolean available,
+        String message
+) {}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/dto/SignupResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/dto/SignupResponseDto.java
@@ -1,0 +1,9 @@
+package com.mzc.backend.lms.domains.user.auth.dto;
+
+/**
+ * 회원가입 응답 DTO
+ */
+public record SignupResponseDto(
+        String userId,
+        String message
+) {}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/exception/AuthErrorCode.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/exception/AuthErrorCode.java
@@ -35,6 +35,10 @@ public enum AuthErrorCode implements DomainErrorCode {
     TOKEN_EXPIRED("AUTH_TOKEN_003", "만료된 토큰입니다", HttpStatus.UNAUTHORIZED),
     REFRESH_TOKEN_INVALID("AUTH_TOKEN_004", "유효하지 않은 리프레시 토큰입니다", HttpStatus.UNAUTHORIZED),
 
+    // 인증/인가 관련 (AUTH_0XX)
+    UNAUTHORIZED("AUTH_AUTH_001", "로그인이 필요합니다", HttpStatus.UNAUTHORIZED),
+    ACCESS_DENIED("AUTH_AUTH_002", "접근 권한이 없습니다", HttpStatus.FORBIDDEN),
+
     // 암호화 관련 (ENCRYPTION_0XX)
     ENCRYPTION_FAILED("AUTH_ENCRYPT_001", "암호화에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
     DECRYPTION_FAILED("AUTH_ENCRYPT_002", "복호화에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/exception/AuthException.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/auth/exception/AuthException.java
@@ -99,4 +99,12 @@ public class AuthException extends CommonException {
     public static AuthException decryptionFailed(Throwable cause) {
         return new AuthException(AuthErrorCode.DECRYPTION_FAILED, cause);
     }
+
+    public static AuthException unauthorized() {
+        return new AuthException(AuthErrorCode.UNAUTHORIZED);
+    }
+
+    public static AuthException accessDenied() {
+        return new AuthException(AuthErrorCode.ACCESS_DENIED);
+    }
 }


### PR DESCRIPTION
## Summary
- ApiResponse<T> record 클래스 추가로 모든 API 응답 일관성 확보
- ErrorInfo record로 에러 응답 표준화
- 20+ 컨트롤러에서 try-catch 제거 및 도메인 예외로 전환
- Inner record를 별도 DTO 파일로 분리

## Changes
### 신규 파일
- `common/response/ApiResponse.java` - API 응답 wrapper record
- `common/response/ErrorInfo.java` - 에러 정보 record
- `notification/dto/UnreadCountResponseDto.java`
- `notification/dto/BulkUpdateResponseDto.java`
- `notification/dto/BulkDeleteResponseDto.java`
- `user/auth/dto/SignupResponseDto.java`
- `user/auth/dto/EmailAvailabilityResponseDto.java`

### 수정된 컨트롤러 (20+)
- AuthController, AttendanceController (Student/Professor)
- NotificationController, EnrollmentController, CartController
- CourseController, CourseNoticeController, CourseWeekContentController
- ProfessorCourseController, ProfessorWeekContentController
- StudentGradeController, ProfessorGradePublishController, ProfessorGradeQueryController
- AssessmentProfessorController, AssessmentStudentController
- AcademicTermCurrentController, ProfessorAcademicTermController, StudentAcademicTermController
- StudentDashboardController

### 예외 클래스 업데이트
- AuthErrorCode: UNAUTHORIZED, ACCESS_DENIED 추가
- AuthException: unauthorized(), accessDenied() 팩토리 메서드 추가
- AttendanceErrorCode: WEEK_NOT_FOUND 추가
- AttendanceException: weekNotFound() 팩토리 메서드 추가

## Test plan
- [x] 빌드 성공 확인
- [x] 기존 테스트 통과 확인
- [ ] API 엔드포인트 응답 형식 확인

closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)