### PR TITLE
feat(board): Port 인터페이스 추가 (#40)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/AttachmentUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/AttachmentUseCase.java
@@ -1,0 +1,47 @@
+package com.mzc.backend.lms.domains.board.application.port.in;
+
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.response.AttachmentResponseDto;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Attachment;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Comment;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * 첨부파일 UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface AttachmentUseCase {
+
+    /**
+     * 단일 파일 업로드
+     */
+    AttachmentResponseDto uploadFile(MultipartFile file, String ignoredType, Post post, Comment comment);
+
+    /**
+     * 다중 파일 업로드
+     */
+    List<AttachmentResponseDto> uploadMultipleFiles(List<MultipartFile> files, String ignoredType);
+
+    /**
+     * 첨부파일 조회
+     */
+    AttachmentResponseDto getAttachment(Long attachmentId);
+
+    /**
+     * 첨부파일 삭제
+     */
+    void deleteAttachment(Long attachmentId);
+
+    /**
+     * 파일 다운로드를 위한 실제 파일 가져오기
+     */
+    File getFile(Long attachmentId);
+
+    /**
+     * attachmentIds로 Attachment 엔티티 목록 조회
+     */
+    List<Attachment> getAttachmentsByIds(List<Long> attachmentIds);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/CommentUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/CommentUseCase.java
@@ -1,0 +1,34 @@
+package com.mzc.backend.lms.domains.board.application.port.in;
+
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.request.CommentCreateRequestDto;
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.request.CommentUpdateRequestDto;
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.response.CommentResponseDto;
+
+import java.util.List;
+
+/**
+ * 댓글 UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface CommentUseCase {
+
+    /**
+     * 댓글 생성
+     */
+    CommentResponseDto createComment(CommentCreateRequestDto request);
+
+    /**
+     * 게시글의 모든 댓글 조회
+     */
+    List<CommentResponseDto> getCommentsByPost(Long postId);
+
+    /**
+     * 댓글 수정
+     */
+    CommentResponseDto updateComment(Long commentId, CommentUpdateRequestDto request, Long updatedBy);
+
+    /**
+     * 댓글 삭제 (Soft Delete)
+     */
+    void deleteComment(Long commentId, Long deletedBy);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/HashtagUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/HashtagUseCase.java
@@ -1,0 +1,33 @@
+package com.mzc.backend.lms.domains.board.application.port.in;
+
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Hashtag;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
+
+import java.util.List;
+
+/**
+ * 해시태그 UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface HashtagUseCase {
+
+    /**
+     * 해시태그 이름으로 조회 또는 생성
+     */
+    Hashtag getOrCreateHashtag(String tagName, Long userId);
+
+    /**
+     * 게시글에 해시태그 목록 연결
+     */
+    void attachHashtagsToPost(Post post, List<String> tagNames, Long userId);
+
+    /**
+     * 게시글의 해시태그 업데이트
+     */
+    void updatePostHashtags(Post post, List<String> tagNames, Long userId);
+
+    /**
+     * 해시태그 검색 (자동완성용)
+     */
+    List<Hashtag> searchHashtags(String keyword);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/PostUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/in/PostUseCase.java
@@ -1,0 +1,65 @@
+package com.mzc.backend.lms.domains.board.application.port.in;
+
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.request.PostCreateRequestDto;
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.request.PostUpdateRequestDto;
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.response.PostListResponseDto;
+import com.mzc.backend.lms.domains.board.adapter.in.web.dto.response.PostResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * 게시글 UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface PostUseCase {
+
+    /**
+     * 게시글 생성 (boardType 기반, 2단계 업로드)
+     */
+    PostResponseDto createPost(String boardTypeStr, PostCreateRequestDto request, Long authorId);
+
+    /**
+     * 게시글 목록 조회 (boardType 기반, 해시태그 필터링 지원)
+     */
+    Page<PostListResponseDto> getPostListByBoardType(String boardTypeStr, String search, String hashtag, Pageable pageable, Long currentUserId);
+
+    /**
+     * 게시글 상세 조회 (조회수 증가)
+     */
+    PostResponseDto getPost(String boardTypeStr, Long postId, Long currentUserId);
+
+    /**
+     * 게시글 상세 조회 (조회수 증가) - 레거시 메서드
+     * @deprecated boardType을 받는 getPost(String, Long) 사용 권장
+     */
+    @Deprecated
+    PostResponseDto getPost(Long postId);
+
+    /**
+     * 게시글 목록 조회 (페이징 + 검색)
+     */
+    Page<PostListResponseDto> getPostList(Long categoryId, String keyword, Pageable pageable);
+
+    /**
+     * 게시글 수정
+     */
+    PostResponseDto updatePost(Long postId, PostUpdateRequestDto request, List<MultipartFile> files, Long updatedBy);
+
+    /**
+     * 게시글 삭제 (Soft Delete)
+     */
+    void deletePost(Long postId);
+
+    /**
+     * 게시글 좋아요 토글 (중복 방지)
+     */
+    boolean toggleLike(Long postId, Long userId);
+
+    /**
+     * 사용자의 게시글 좋아요 여부 조회
+     */
+    boolean isLikedByUser(Long postId, Long userId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/AttachmentRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/AttachmentRepositoryPort.java
@@ -1,0 +1,43 @@
+package com.mzc.backend.lms.domains.board.application.port.out;
+
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Attachment;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Attachment 영속성을 위한 Port
+ */
+public interface AttachmentRepositoryPort {
+
+    /**
+     * 첨부파일 저장
+     */
+    Attachment save(Attachment attachment);
+
+    /**
+     * ID로 첨부파일 조회
+     */
+    Optional<Attachment> findById(Long id);
+
+    /**
+     * ID 목록으로 첨부파일 목록 조회
+     */
+    List<Attachment> findAllById(Iterable<Long> ids);
+
+    /**
+     * 게시글의 첨부파일 목록 조회
+     */
+    List<Attachment> findByPost(Post post);
+
+    /**
+     * 첨부파일 삭제
+     */
+    void delete(Attachment attachment);
+
+    /**
+     * 첨부파일 목록 저장
+     */
+    List<Attachment> saveAll(Iterable<Attachment> attachments);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/BoardCategoryRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/BoardCategoryRepositoryPort.java
@@ -1,0 +1,27 @@
+package com.mzc.backend.lms.domains.board.application.port.out;
+
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.BoardCategory;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.enums.BoardType;
+
+import java.util.Optional;
+
+/**
+ * BoardCategory 영속성을 위한 Port
+ */
+public interface BoardCategoryRepositoryPort {
+
+    /**
+     * 게시판 카테고리 저장
+     */
+    BoardCategory save(BoardCategory boardCategory);
+
+    /**
+     * ID로 게시판 카테고리 조회
+     */
+    Optional<BoardCategory> findById(Long id);
+
+    /**
+     * 게시판 유형으로 카테고리 조회
+     */
+    Optional<BoardCategory> findByBoardType(BoardType boardType);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/CommentRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/CommentRepositoryPort.java
@@ -1,0 +1,33 @@
+package com.mzc.backend.lms.domains.board.application.port.out;
+
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Comment;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Comment 영속성을 위한 Port
+ */
+public interface CommentRepositoryPort {
+
+    /**
+     * 댓글 저장
+     */
+    Comment save(Comment comment);
+
+    /**
+     * ID로 댓글 조회
+     */
+    Optional<Comment> findById(Long id);
+
+    /**
+     * 게시글의 댓글 목록 조회
+     */
+    List<Comment> findByPost(Post post);
+
+    /**
+     * 부모 댓글의 자식 댓글 목록 조회
+     */
+    List<Comment> findByParentComment(Comment parentComment);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/HashtagRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/HashtagRepositoryPort.java
@@ -1,0 +1,42 @@
+package com.mzc.backend.lms.domains.board.application.port.out;
+
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Hashtag;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Hashtag 영속성을 위한 Port
+ */
+public interface HashtagRepositoryPort {
+
+    /**
+     * 해시태그 저장
+     */
+    Hashtag save(Hashtag hashtag);
+
+    /**
+     * ID로 해시태그 조회
+     */
+    Optional<Hashtag> findById(Long id);
+
+    /**
+     * 이름으로 해시태그 조회
+     */
+    Optional<Hashtag> findByName(String name);
+
+    /**
+     * 이름과 활성 상태로 해시태그 존재 여부 확인
+     */
+    boolean existsByNameAndIsActive(String name, boolean isActive);
+
+    /**
+     * 해시태그 이름으로 검색 (자동완성용)
+     */
+    List<Hashtag> searchActiveHashtagsByKeyword(String keyword);
+
+    /**
+     * 해시태그 이름으로 검색 (name과 displayName 모두 검색, 자동완성용)
+     */
+    List<Hashtag> searchActiveHashtagsByKeywordInBoth(String keyword);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/PostLikeRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/PostLikeRepositoryPort.java
@@ -1,0 +1,52 @@
+package com.mzc.backend.lms.domains.board.application.port.out;
+
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.PostLike;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * PostLike 영속성을 위한 Port
+ */
+public interface PostLikeRepositoryPort {
+
+    /**
+     * 좋아요 저장
+     */
+    PostLike save(PostLike postLike);
+
+    /**
+     * ID로 좋아요 조회
+     */
+    Optional<PostLike> findById(Long id);
+
+    /**
+     * 사용자의 특정 게시글 좋아요 조회
+     */
+    Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId);
+
+    /**
+     * 사용자의 특정 게시글 좋아요 여부 확인
+     */
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    /**
+     * 사용자가 좋아요한 게시글 ID 목록 조회
+     */
+    List<Long> findLikedPostIdsByUserIdAndPostIds(Long userId, List<Long> postIds);
+
+    /**
+     * 게시글의 좋아요 수 카운트
+     */
+    long countByPostId(Long postId);
+
+    /**
+     * 게시글의 모든 좋아요 삭제
+     */
+    void deleteByPostId(Long postId);
+
+    /**
+     * 좋아요 삭제
+     */
+    void delete(PostLike postLike);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/PostRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/port/out/PostRepositoryPort.java
@@ -1,0 +1,80 @@
+package com.mzc.backend.lms.domains.board.application.port.out;
+
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.BoardCategory;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Post 영속성을 위한 Port
+ */
+public interface PostRepositoryPort {
+
+    /**
+     * 게시글 저장
+     */
+    Post save(Post post);
+
+    /**
+     * ID로 게시글 조회
+     */
+    Optional<Post> findById(Long id);
+
+    /**
+     * ID로 게시글 조회 (모든 연관관계 즉시 로딩)
+     */
+    Optional<Post> findWithAllById(Long id);
+
+    /**
+     * 카테고리로 게시글 목록 조회
+     */
+    List<Post> findByCategory(BoardCategory category);
+
+    /**
+     * 카테고리로 게시글 페이징 조회
+     */
+    Page<Post> findByCategory(BoardCategory category, Pageable pageable);
+
+    /**
+     * 제목으로 게시글 검색 (페이징)
+     */
+    Page<Post> findByTitleContaining(String title, Pageable pageable);
+
+    /**
+     * 카테고리와 제목으로 게시글 검색 (페이징)
+     */
+    Page<Post> findByCategoryAndTitleContaining(BoardCategory category, String title, Pageable pageable);
+
+    /**
+     * 카테고리와 해시태그로 게시글 검색 (페이징)
+     */
+    Page<Post> findByCategoryAndHashtagName(BoardCategory category, String hashtagName, Pageable pageable);
+
+    /**
+     * 카테고리, 제목, 해시태그로 게시글 검색 (페이징)
+     */
+    Page<Post> findByCategoryAndTitleContainingAndHashtagName(BoardCategory category, String title, String hashtagName, Pageable pageable);
+
+    /**
+     * 카테고리와 학과 ID로 게시글 검색 (페이징)
+     */
+    Page<Post> findByCategoryAndDepartmentId(BoardCategory category, Long departmentId, Pageable pageable);
+
+    /**
+     * 카테고리, 학과 ID, 제목으로 게시글 검색 (페이징)
+     */
+    Page<Post> findByCategoryAndDepartmentIdAndTitleContaining(BoardCategory category, Long departmentId, String title, Pageable pageable);
+
+    /**
+     * 게시글 상세 조회 (해시태그 포함)
+     */
+    Optional<Post> findByIdWithHashtags(Long postId);
+
+    /**
+     * 전체 게시글 페이징 조회
+     */
+    Page<Post> findAll(Pageable pageable);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/AttachmentService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/AttachmentService.java
@@ -5,6 +5,7 @@ import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Attachme
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Comment;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.enums.AttachmentType;
+import com.mzc.backend.lms.domains.board.application.port.in.AttachmentUseCase;
 import com.mzc.backend.lms.domains.board.exception.BoardException;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.repository.AttachmentRepositoryJpa;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AttachmentService {
+public class AttachmentService implements AttachmentUseCase {
 
     private final AttachmentRepositoryJpa attachmentRepository;
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/CommentService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/CommentService.java
@@ -8,6 +8,7 @@ import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Attachme
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.BoardCategory;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Comment;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
+import com.mzc.backend.lms.domains.board.application.port.in.CommentUseCase;
 import com.mzc.backend.lms.domains.board.exception.BoardErrorCode;
 import com.mzc.backend.lms.domains.board.exception.BoardException;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.repository.AttachmentRepositoryJpa;
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class CommentService {
+public class CommentService implements CommentUseCase {
 
     private final CommentRepositoryJpa commentRepository;
     private final PostRepositoryJpa postRepository;

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/HashtagService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/HashtagService.java
@@ -2,6 +2,7 @@ package com.mzc.backend.lms.domains.board.application.service;
 
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Hashtag;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.entity.Post;
+import com.mzc.backend.lms.domains.board.application.port.in.HashtagUseCase;
 import com.mzc.backend.lms.domains.board.exception.BoardException;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.repository.HashtagRepositoryJpa;
 import jakarta.persistence.EntityManager;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class HashtagService {
+public class HashtagService implements HashtagUseCase {
 
     private final HashtagRepositoryJpa hashtagRepository;
     private final EntityManager entityManager;

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/PostService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/application/service/PostService.java
@@ -17,6 +17,7 @@ import com.mzc.backend.lms.domains.board.adapter.out.persistence.repository.Boar
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.repository.PostLikeRepositoryJpa;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.repository.PostRepositoryJpa;
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.repository.UserTypeQueryRepositoryJpa;
+import com.mzc.backend.lms.domains.board.application.port.in.PostUseCase;
 import com.mzc.backend.lms.domains.user.adapter.in.web.dto.profile.UserBasicInfoDto;
 import com.mzc.backend.lms.domains.user.application.port.in.GetUserInfoCacheUseCase;
 import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.User;
@@ -42,7 +43,7 @@ import java.util.Set;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class PostService {
+public class PostService implements PostUseCase {
 
     private final PostRepositoryJpa postRepository;
     private final BoardCategoryRepositoryJpa boardCategoryRepository;


### PR DESCRIPTION
## Summary
Board 도메인에 헥사고날 아키텍처 Port 인터페이스를 추가했습니다.

### UseCase 인터페이스 (In Port)
- PostUseCase.java - 게시글 관련 비즈니스 로직 인터페이스
- CommentUseCase.java - 댓글 관련 비즈니스 로직 인터페이스
- HashtagUseCase.java - 해시태그 관련 비즈니스 로직 인터페이스
- AttachmentUseCase.java - 첨부파일 관련 비즈니스 로직 인터페이스

### RepositoryPort 인터페이스 (Out Port)
- PostRepositoryPort.java - 게시글 영속성 포트
- CommentRepositoryPort.java - 댓글 영속성 포트
- HashtagRepositoryPort.java - 해시태그 영속성 포트
- AttachmentRepositoryPort.java - 첨부파일 영속성 포트
- BoardCategoryRepositoryPort.java - 게시판 카테고리 영속성 포트
- PostLikeRepositoryPort.java - 게시글 좋아요 영속성 포트

### Service 구현 변경
- PostService implements PostUseCase
- CommentService implements CommentUseCase
- HashtagService implements HashtagUseCase
- AttachmentService implements AttachmentUseCase

## Changes
- application/port/in 디렉토리에 4개의 UseCase 인터페이스 추가
- application/port/out 디렉토리에 6개의 RepositoryPort 인터페이스 추가
- 4개의 Service 클래스가 각각 대응하는 UseCase 인터페이스 구현

## Test plan
- [x] 코드 컴파일 검증 완료
- [ ] 기존 API 동작 확인
- [ ] 단위 테스트 실행 (필요시)