### PR TITLE
feat(attendance): Port 인터페이스 추가 (#41)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/in/AttendanceEventUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/in/AttendanceEventUseCase.java
@@ -1,0 +1,16 @@
+package com.mzc.backend.lms.domains.attendance.application.port.in;
+
+import com.mzc.backend.lms.domains.attendance.application.event.ContentCompletedEvent;
+
+/**
+ * 출석 이벤트 처리 UseCase (Inbound Port)
+ * Event Listener에서 이 인터페이스를 호출
+ */
+public interface AttendanceEventUseCase {
+
+    /**
+     * 콘텐츠 완료 이벤트 처리
+     * Video Server에서 발행한 이벤트를 수신하여 출석 상태 갱신
+     */
+    void processContentCompleted(ContentCompletedEvent event);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/in/ProfessorAttendanceUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/in/ProfessorAttendanceUseCase.java
@@ -1,0 +1,29 @@
+package com.mzc.backend.lms.domains.attendance.application.port.in;
+
+import com.mzc.backend.lms.domains.attendance.adapter.in.web.dto.CourseAttendanceOverviewDto;
+import com.mzc.backend.lms.domains.attendance.adapter.in.web.dto.StudentAttendanceDto;
+import com.mzc.backend.lms.domains.attendance.adapter.in.web.dto.WeekStudentAttendanceDto;
+
+import java.util.List;
+
+/**
+ * 교수용 출석 조회 UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface ProfessorAttendanceUseCase {
+
+    /**
+     * 교수의 강의 전체 출석 현황 조회
+     */
+    CourseAttendanceOverviewDto getProfessorCourseAttendance(Long professorId, Long courseId);
+
+    /**
+     * 교수의 강의 학생별 출석 목록 조회
+     */
+    List<StudentAttendanceDto> getProfessorStudentAttendances(Long professorId, Long courseId);
+
+    /**
+     * 교수의 주차별 학생 출석 현황 조회
+     */
+    List<WeekStudentAttendanceDto> getProfessorWeekAttendances(Long professorId, Long courseId, Long weekId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/in/StudentAttendanceUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/in/StudentAttendanceUseCase.java
@@ -1,0 +1,23 @@
+package com.mzc.backend.lms.domains.attendance.application.port.in;
+
+import com.mzc.backend.lms.domains.attendance.adapter.in.web.dto.CourseAttendanceDto;
+import com.mzc.backend.lms.domains.attendance.adapter.in.web.dto.CourseAttendanceSummaryDto;
+
+import java.util.List;
+
+/**
+ * 학생용 출석 조회 UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface StudentAttendanceUseCase {
+
+    /**
+     * 학생의 특정 강의 출석 현황 조회
+     */
+    CourseAttendanceDto getStudentCourseAttendance(Long studentId, Long courseId);
+
+    /**
+     * 학생의 전체 출석 현황 조회
+     */
+    List<CourseAttendanceSummaryDto> getStudentAllAttendance(Long studentId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/out/StudentContentProgressRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/out/StudentContentProgressRepositoryPort.java
@@ -1,0 +1,47 @@
+package com.mzc.backend.lms.domains.attendance.application.port.out;
+
+import com.mzc.backend.lms.domains.attendance.adapter.out.persistence.entity.StudentContentProgress;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 학생 콘텐츠 진행 상황 영속성을 위한 Port
+ */
+public interface StudentContentProgressRepositoryPort {
+
+    /**
+     * 진행 상황 저장
+     */
+    StudentContentProgress save(StudentContentProgress progress);
+
+    /**
+     * ID로 진행 상황 조회
+     */
+    Optional<StudentContentProgress> findById(Long id);
+
+    /**
+     * 학생 ID와 콘텐츠 ID로 진행 상황 조회
+     */
+    Optional<StudentContentProgress> findByStudentStudentIdAndContent_Id(Long studentId, Long contentId);
+
+    /**
+     * 학생 ID와 콘텐츠 ID 목록으로 진행 상황 조회
+     */
+    List<StudentContentProgress> findByStudentStudentIdAndContent_IdIn(Long studentId, List<Long> contentIds);
+
+    /**
+     * 학생 ID와 콘텐츠 ID 목록 중 완료된 것만 조회
+     */
+    List<StudentContentProgress> findCompletedByStudentAndContentIds(Long studentId, List<Long> contentIds);
+
+    /**
+     * 학생이 특정 주차에서 완료한 VIDEO 콘텐츠 수 조회
+     */
+    int countCompletedVideosByStudentAndWeek(Long studentId, Long weekId);
+
+    /**
+     * 학생의 특정 강의 전체 진행 상황 조회
+     */
+    List<StudentContentProgress> findByStudentAndCourse(Long studentId, Long courseId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/out/WeekAttendanceRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/port/out/WeekAttendanceRepositoryPort.java
@@ -1,0 +1,72 @@
+package com.mzc.backend.lms.domains.attendance.application.port.out;
+
+import com.mzc.backend.lms.domains.attendance.adapter.out.persistence.entity.WeekAttendance;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 주차별 출석 영속성을 위한 Port
+ */
+public interface WeekAttendanceRepositoryPort {
+
+    /**
+     * 출석 저장
+     */
+    WeekAttendance save(WeekAttendance weekAttendance);
+
+    /**
+     * ID로 출석 조회
+     */
+    Optional<WeekAttendance> findById(Long id);
+
+    /**
+     * 학생 ID와 주차 ID로 출석 조회
+     */
+    Optional<WeekAttendance> findByStudentStudentIdAndWeek_Id(Long studentId, Long weekId);
+
+    /**
+     * 학생의 특정 강의 출석 목록 조회
+     */
+    List<WeekAttendance> findByStudentStudentIdAndCourse_Id(Long studentId, Long courseId);
+
+    /**
+     * 학생의 모든 출석 목록 조회
+     */
+    List<WeekAttendance> findByStudentStudentId(Long studentId);
+
+    /**
+     * 특정 강의의 모든 학생 출석 목록 조회 (교수용)
+     */
+    List<WeekAttendance> findByCourse_Id(Long courseId);
+
+    /**
+     * 특정 주차의 모든 학생 출석 목록 조회 (교수용)
+     */
+    List<WeekAttendance> findByWeek_Id(Long weekId);
+
+    /**
+     * 학생의 특정 강의 출석 완료 주차 수 조회
+     */
+    int countCompletedByStudentAndCourse(Long studentId, Long courseId);
+
+    /**
+     * 특정 강의의 출석 완료 학생 수 조회 (주차별)
+     */
+    int countCompletedByWeek(Long weekId);
+
+    /**
+     * 특정 강의, 주차의 미완료 학생 목록 조회
+     */
+    List<WeekAttendance> findIncompleteByWeek(Long weekId);
+
+    /**
+     * 학생-강의별 출석 통계 조회
+     */
+    List<Object[]> getAttendanceStatsByCourse(Long courseId);
+
+    /**
+     * 학생 ID와 주차 ID 목록으로 출석 조회
+     */
+    List<WeekAttendance> findByStudentAndWeekIds(Long studentId, List<Long> weekIds);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/service/AttendanceService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/application/service/AttendanceService.java
@@ -3,6 +3,9 @@ package com.mzc.backend.lms.domains.attendance.application.service;
 import com.mzc.backend.lms.domains.attendance.adapter.in.web.dto.*;
 import com.mzc.backend.lms.domains.attendance.adapter.out.persistence.entity.WeekAttendance;
 import com.mzc.backend.lms.domains.attendance.application.event.ContentCompletedEvent;
+import com.mzc.backend.lms.domains.attendance.application.port.in.AttendanceEventUseCase;
+import com.mzc.backend.lms.domains.attendance.application.port.in.ProfessorAttendanceUseCase;
+import com.mzc.backend.lms.domains.attendance.application.port.in.StudentAttendanceUseCase;
 import com.mzc.backend.lms.domains.attendance.exception.AttendanceException;
 import com.mzc.backend.lms.domains.attendance.adapter.out.persistence.repository.StudentContentProgressJpaRepository;
 import com.mzc.backend.lms.domains.attendance.adapter.out.persistence.repository.WeekAttendanceJpaRepository;
@@ -30,7 +33,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AttendanceService {
+public class AttendanceService implements StudentAttendanceUseCase, ProfessorAttendanceUseCase, AttendanceEventUseCase {
 
     private final WeekAttendanceJpaRepository weekAttendanceRepository;
     private final StudentContentProgressJpaRepository progressRepository;
@@ -45,6 +48,7 @@ public class AttendanceService {
      * 콘텐츠 완료 이벤트 처리
      * Video Server에서 발행한 이벤트를 수신하여 출석 상태 갱신
      */
+    @Override
     @Transactional
     public void processContentCompleted(ContentCompletedEvent event) {
         log.info("Processing content completed event: studentId={}, weekId={}, contentId={}",
@@ -111,6 +115,7 @@ public class AttendanceService {
     /**
      * 학생의 특정 강의 출석 현황 조회
      */
+    @Override
     @Transactional(readOnly = true)
     public CourseAttendanceDto getStudentCourseAttendance(Long studentId, Long courseId) {
         // 수강 여부 확인
@@ -174,6 +179,7 @@ public class AttendanceService {
     /**
      * 학생의 전체 출석 현황 조회
      */
+    @Override
     @Transactional(readOnly = true)
     public List<CourseAttendanceSummaryDto> getStudentAllAttendance(Long studentId) {
         // 학생이 수강 중인 강의 목록 조회
@@ -216,6 +222,7 @@ public class AttendanceService {
     /**
      * 교수의 강의 전체 출석 현황 조회
      */
+    @Override
     @Transactional(readOnly = true)
     public CourseAttendanceOverviewDto getProfessorCourseAttendance(Long professorId, Long courseId) {
         // 교수 권한 확인
@@ -268,6 +275,7 @@ public class AttendanceService {
     /**
      * 교수의 강의 학생별 출석 목록 조회
      */
+    @Override
     @Transactional(readOnly = true)
     public List<StudentAttendanceDto> getProfessorStudentAttendances(Long professorId, Long courseId) {
         // 교수 권한 확인
@@ -301,6 +309,7 @@ public class AttendanceService {
     /**
      * 교수의 주차별 학생 출석 현황 조회
      */
+    @Override
     @Transactional(readOnly = true)
     public List<WeekStudentAttendanceDto> getProfessorWeekAttendances(Long professorId, Long courseId, Long weekId) {
         // 교수 권한 확인


### PR DESCRIPTION
## Summary
Attendance 도메인에 헥사고날 아키텍처 Port 인터페이스를 추가했습니다.

### 추가된 Inbound Port (UseCase)
- `StudentAttendanceUseCase`: 학생용 출석 조회
  - getStudentCourseAttendance
  - getStudentAllAttendance
- `ProfessorAttendanceUseCase`: 교수용 출석 조회
  - getProfessorCourseAttendance
  - getProfessorStudentAttendances
  - getProfessorWeekAttendances
- `AttendanceEventUseCase`: 이벤트 처리
  - processContentCompleted

### 추가된 Outbound Port (Repository)
- `WeekAttendanceRepositoryPort`: 주차별 출석 영속성 인터페이스
- `StudentContentProgressRepositoryPort`: 학생 콘텐츠 진행 상황 영속성 인터페이스

### 변경사항
- AttendanceService가 UseCase 인터페이스를 구현하도록 수정
- 모든 public 메서드에 @Override 어노테이션 추가

## Test plan
- [ ] 기존 출석 조회 기능이 정상 동작하는지 확인
- [ ] 컴파일 오류가 없는지 확인
- [ ] 의존성 주입이 정상적으로 동작하는지 확인