### PR TITLE
feat(assessment): Port 인터페이스 추가 (#42)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/in/AssessmentProfessorUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/in/AssessmentProfessorUseCase.java
@@ -1,0 +1,61 @@
+package com.mzc.backend.lms.domains.assessment.application.port.in;
+
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.request.AssessmentCreateRequestDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.request.AssessmentUpdateRequestDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.request.AttemptGradeRequestDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.AssessmentDetailResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.AssessmentListItemResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.AttemptGradeResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.ProfessorAttemptDetailResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.ProfessorAttemptListItemResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.enums.AssessmentType;
+import com.mzc.backend.lms.domains.board.adapter.out.persistence.enums.BoardType;
+
+import java.util.List;
+
+/**
+ * 교수용 Assessment UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface AssessmentProfessorUseCase {
+
+    /**
+     * 교수용 평가 목록 조회
+     */
+    List<AssessmentListItemResponseDto> listForProfessor(Long courseId, AssessmentType type, long professorId);
+
+    /**
+     * 교수용 평가 상세 조회
+     */
+    AssessmentDetailResponseDto getDetailForProfessor(Long assessmentId, long professorId);
+
+    /**
+     * 평가 생성
+     */
+    AssessmentDetailResponseDto create(BoardType boardType, AssessmentCreateRequestDto req, long professorId);
+
+    /**
+     * 평가 수정
+     */
+    AssessmentDetailResponseDto update(Long assessmentId, AssessmentUpdateRequestDto req, long professorId);
+
+    /**
+     * 평가 삭제
+     */
+    void delete(Long assessmentId, long professorId);
+
+    /**
+     * 응시자/응시 결과 목록 조회 (교수)
+     */
+    List<ProfessorAttemptListItemResponseDto> listAttemptsForProfessor(Long assessmentId, String status, long professorId);
+
+    /**
+     * 응시 결과 상세 조회(답안 포함) (교수)
+     */
+    ProfessorAttemptDetailResponseDto getAttemptDetailForProfessor(Long attemptId, long professorId);
+
+    /**
+     * 시험 채점 (교수)
+     */
+    AttemptGradeResponseDto gradeAttempt(Long attemptId, AttemptGradeRequestDto req, long professorId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/in/AssessmentStudentUseCase.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/in/AssessmentStudentUseCase.java
@@ -1,0 +1,37 @@
+package com.mzc.backend.lms.domains.assessment.application.port.in;
+
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.request.AttemptSubmitRequestDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.AssessmentDetailResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.AssessmentListItemResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.AttemptStartResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response.AttemptSubmitResponseDto;
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.enums.AssessmentType;
+
+import java.util.List;
+
+/**
+ * 학생용 Assessment UseCase (Inbound Port)
+ * Controller에서 이 인터페이스를 호출
+ */
+public interface AssessmentStudentUseCase {
+
+    /**
+     * 학생용 평가 목록 조회
+     */
+    List<AssessmentListItemResponseDto> listForStudent(Long courseId, AssessmentType type, long studentId);
+
+    /**
+     * 학생용 평가 상세 조회
+     */
+    AssessmentDetailResponseDto getDetailForStudent(Long assessmentId, long studentId);
+
+    /**
+     * 응시 시작
+     */
+    AttemptStartResponseDto startAttempt(Long assessmentId, long studentId);
+
+    /**
+     * 응시 제출
+     */
+    AttemptSubmitResponseDto submitAttempt(Long attemptId, AttemptSubmitRequestDto req, long studentId);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/out/AssessmentAttemptRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/out/AssessmentAttemptRepositoryPort.java
@@ -1,0 +1,43 @@
+package com.mzc.backend.lms.domains.assessment.application.port.out;
+
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.AssessmentAttempt;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * AssessmentAttempt 영속성을 위한 Port
+ */
+public interface AssessmentAttemptRepositoryPort {
+
+    /**
+     * 응시 저장
+     */
+    AssessmentAttempt save(AssessmentAttempt attempt);
+
+    /**
+     * ID로 응시 조회 (Assessment와 함께)
+     */
+    Optional<AssessmentAttempt> findActiveWithAssessment(Long id);
+
+    /**
+     * 평가 ID와 상태로 응시 목록 조회
+     */
+    List<AssessmentAttempt> findActiveByAssessmentIdAndStatus(Long assessmentId, String status);
+
+    /**
+     * 평가 ID와 사용자 ID로 응시 조회
+     */
+    Optional<AssessmentAttempt> findActiveByAssessmentIdAndUserId(Long assessmentId, Long userId);
+
+    /**
+     * 미채점된 제출 응시가 있는지 확인
+     */
+    boolean existsUngradedSubmittedByAssessmentIds(List<Long> assessmentIds);
+
+    /**
+     * 사용자의 채점된 점수 합계 조회
+     */
+    BigDecimal sumGradedScoreByUserAndAssessmentIds(Long userId, List<Long> assessmentIds);
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/out/AssessmentRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/application/port/out/AssessmentRepositoryPort.java
@@ -1,0 +1,34 @@
+package com.mzc.backend.lms.domains.assessment.application.port.out;
+
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.Assessment;
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.enums.AssessmentType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Assessment 영속성을 위한 Port
+ */
+public interface AssessmentRepositoryPort {
+
+    /**
+     * 평가 저장
+     */
+    Assessment save(Assessment assessment);
+
+    /**
+     * ID로 평가 조회 (Post와 함께)
+     */
+    Optional<Assessment> findActiveWithPost(Long id);
+
+    /**
+     * 강의와 타입으로 평가 목록 조회 (교수용)
+     */
+    List<Assessment> findActiveByCourse(Long courseId, AssessmentType type);
+
+    /**
+     * 강의와 타입으로 학생에게 보이는 평가 목록 조회
+     */
+    List<Assessment> findVisibleByCourseForStudent(Long courseId, AssessmentType type, LocalDateTime now);
+}


### PR DESCRIPTION
## Summary
- AssessmentProfessorUseCase 인터페이스 생성 (교수용: listForProfessor, getDetailForProfessor, create, update, delete, listAttemptsForProfessor, getAttemptDetailForProfessor, gradeAttempt)
- AssessmentStudentUseCase 인터페이스 생성 (학생용: listForStudent, getDetailForStudent, startAttempt, submitAttempt)
- AssessmentRepositoryPort 인터페이스 생성 (findActiveWithPost, findActiveByCourse, findVisibleByCourseForStudent)
- AssessmentAttemptRepositoryPort 인터페이스 생성 (findActiveWithAssessment, findActiveByAssessmentIdAndStatus, findActiveByAssessmentIdAndUserId 등)
- AssessmentService가 AssessmentProfessorUseCase와 AssessmentStudentUseCase 구현

## Changes
- application/port/in/AssessmentProfessorUseCase.java (신규)
- application/port/in/AssessmentStudentUseCase.java (신규)
- application/port/out/AssessmentRepositoryPort.java (신규)
- application/port/out/AssessmentAttemptRepositoryPort.java (신규)
- application/service/AssessmentService.java (수정: UseCase 인터페이스 구현)

## Architecture
헥사고날 아키텍처 패턴 적용:
- Inbound Port: Controller가 호출하는 UseCase 인터페이스 (교수용/학생용 분리)
- Outbound Port: Service가 사용하는 Repository 인터페이스
- Service는 UseCase를 구현하고 Repository Port를 통해 영속성 계층과 통신

Fixes #42