### PR TITLE
feat(dto): 정적 팩토리 메서드 패턴 적용 (#4)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/adapter/in/web/dto/ProfessorCourseGradesResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/adapter/in/web/dto/ProfessorCourseGradesResponseDto.java
@@ -1,10 +1,13 @@
 package com.mzc.backend.lms.domains.course.grade.adapter.in.web.dto;
 
+import com.mzc.backend.lms.domains.course.grade.adapter.out.persistence.entity.Grade;
+import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Student;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -32,6 +35,52 @@ public class ProfessorCourseGradesResponseDto {
         private Long id;
         private Long studentNumber;
         private String name;
+
+        /**
+         * Entity -> DTO 변환
+         */
+        public static StudentDto from(Student student) {
+            if (student == null) {
+                return null;
+            }
+            return StudentDto.builder()
+                    .id(student.getId())
+                    .studentNumber(student.getStudentNumber())
+                    .name(student.getUser() != null && student.getUser().getUserProfile() != null ?
+                          student.getUser().getUserProfile().getName() : null)
+                    .build();
+        }
+    }
+
+    /**
+     * Entity -> DTO 변환 (기본 정보만, courseName과 student는 별도 설정 필요)
+     */
+    public static ProfessorCourseGradesResponseDto from(Grade grade) {
+        return ProfessorCourseGradesResponseDto.builder()
+                .courseId(grade.getCourseId())
+                .academicTermId(grade.getAcademicTermId())
+                .courseName(null)  // 서비스 레이어에서 설정
+                .student(null)  // 서비스 레이어에서 설정
+                .midtermScore(grade.getMidtermScore())
+                .finalExamScore(grade.getFinalExamScore())
+                .quizScore(grade.getQuizScore())
+                .assignmentScore(grade.getAssignmentScore())
+                .attendanceScore(grade.getAttendanceScore())
+                .finalScore(grade.getFinalScore())
+                .finalGrade(grade.getFinalGrade())
+                .status(grade.getStatus() != null ? grade.getStatus().name() : null)
+                .gradedAt(grade.getGradedAt())
+                .publishedAt(grade.getPublishedAt())
+                .build();
+    }
+
+    /**
+     * Entity List -> DTO List 변환
+     */
+    public static List<ProfessorCourseGradesResponseDto> from(List<Grade> grades) {
+        return grades.stream()
+                .map(ProfessorCourseGradesResponseDto::from)
+                .toList();
     }
 }
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/adapter/in/web/dto/StudentGradeResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/adapter/in/web/dto/StudentGradeResponseDto.java
@@ -1,10 +1,12 @@
 package com.mzc.backend.lms.domains.course.grade.adapter.in.web.dto;
 
+import com.mzc.backend.lms.domains.course.grade.adapter.out.persistence.entity.Grade;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -24,6 +26,36 @@ public class StudentGradeResponseDto {
     private BigDecimal finalScore;
     private String finalGrade;
     private LocalDateTime publishedAt;
+
+    /**
+     * Entity -> DTO 변환 (기본 정보만, courseName과 courseCredits는 별도 설정 필요)
+     */
+    public static StudentGradeResponseDto from(Grade grade) {
+        return StudentGradeResponseDto.builder()
+                .academicTermId(grade.getAcademicTermId())
+                .courseId(grade.getCourseId())
+                .courseName(null)  // 서비스 레이어에서 설정
+                .courseCredits(null)  // 서비스 레이어에서 설정
+                .status(grade.getStatus() != null ? grade.getStatus().name() : null)
+                .midtermScore(grade.getMidtermScore())
+                .finalExamScore(grade.getFinalExamScore())
+                .quizScore(grade.getQuizScore())
+                .assignmentScore(grade.getAssignmentScore())
+                .attendanceScore(grade.getAttendanceScore())
+                .finalScore(grade.getFinalScore())
+                .finalGrade(grade.getFinalGrade())
+                .publishedAt(grade.getPublishedAt())
+                .build();
+    }
+
+    /**
+     * Entity List -> DTO List 변환
+     */
+    public static List<StudentGradeResponseDto> from(List<Grade> grades) {
+        return grades.stream()
+                .map(StudentGradeResponseDto::from)
+                .toList();
+    }
 }
 
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/adapter/in/web/dto/SubjectDetailResponse.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/adapter/in/web/dto/SubjectDetailResponse.java
@@ -1,5 +1,7 @@
 package com.mzc.backend.lms.domains.course.subject.adapter.in.web.dto;
 
+import com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.Course;
+import com.mzc.backend.lms.domains.course.subject.adapter.out.persistence.entity.Subject;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +43,23 @@ public class SubjectDetailResponse {
         private TermDto term;
         private Integer currentStudents;
         private Integer maxStudents;
+
+        /**
+         * Entity -> DTO 변환
+         */
+        public static CourseInfoDto from(Course course) {
+            if (course == null) {
+                return null;
+            }
+            return CourseInfoDto.builder()
+                    .id(course.getId())
+                    .section(course.getSectionNumber())
+                    .professor(course.getProfessor() != null ? ProfessorDto.from(course.getProfessor()) : null)
+                    .term(course.getAcademicTerm() != null ? TermDto.from(course.getAcademicTerm()) : null)
+                    .currentStudents(course.getCurrentStudents())
+                    .maxStudents(course.getMaxStudents())
+                    .build();
+        }
     }
 
     @Getter
@@ -50,6 +69,20 @@ public class SubjectDetailResponse {
     public static class ProfessorDto {
         private Long id;
         private String name;
+
+        /**
+         * Entity -> DTO 변환
+         */
+        public static ProfessorDto from(com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Professor professor) {
+            if (professor == null) {
+                return null;
+            }
+            return ProfessorDto.builder()
+                    .id(professor.getId())
+                    .name(professor.getUser() != null && professor.getUser().getUserProfile() != null ?
+                          professor.getUser().getUserProfile().getName() : null)
+                    .build();
+        }
     }
 
     @Getter
@@ -59,6 +92,55 @@ public class SubjectDetailResponse {
     public static class TermDto {
         private Integer year;
         private String termType;
+
+        /**
+         * Entity -> DTO 변환
+         */
+        public static TermDto from(com.mzc.backend.lms.domains.academy.adapter.out.persistence.entity.AcademicTerm term) {
+            if (term == null) {
+                return null;
+            }
+            return TermDto.builder()
+                    .year(term.getYear())
+                    .termType(term.getTermType())
+                    .build();
+        }
+    }
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static SubjectDetailResponse from(Subject subject) {
+        return SubjectDetailResponse.builder()
+                .id(subject.getId())
+                .subjectCode(subject.getSubjectCode())
+                .subjectName(subject.getSubjectName())
+                .englishName(null)  // 영문명은 아직 DB에 없음
+                .credits(subject.getCredits())
+                .courseType(SubjectResponse.CourseTypeDto.from(subject.getCourseType()))
+                .department(SubjectResponse.DepartmentDto.from(subject.getDepartment()))
+                .description(subject.getDescription())
+                .objectives(List.of())  // objectives는 별도 처리 필요
+                .prerequisites(subject.getPrerequisites() != null ?
+                        subject.getPrerequisites().stream()
+                                .map(SubjectResponse.PrerequisiteDto::from)
+                                .toList() : List.of())
+                .courses(subject.getCourses() != null ?
+                        subject.getCourses().stream()
+                                .map(CourseInfoDto::from)
+                                .toList() : List.of())
+                .isActive(true)  // 기본값
+                .createdAt(subject.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * Entity List -> DTO List 변환
+     */
+    public static List<SubjectDetailResponse> from(List<Subject> subjects) {
+        return subjects.stream()
+                .map(SubjectDetailResponse::from)
+                .toList();
     }
 }
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/adapter/in/web/dto/SubjectResponse.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/adapter/in/web/dto/SubjectResponse.java
@@ -1,5 +1,7 @@
 package com.mzc.backend.lms.domains.course.subject.adapter.in.web.dto;
 
+import com.mzc.backend.lms.domains.course.subject.adapter.out.persistence.entity.Subject;
+import com.mzc.backend.lms.domains.course.subject.adapter.out.persistence.entity.SubjectPrerequisites;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +40,21 @@ public class SubjectResponse {
         private String code;
         private String name;
         private String color;
+
+        /**
+         * Entity -> DTO 변환
+         */
+        public static CourseTypeDto from(com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.CourseType courseType) {
+            if (courseType == null) {
+                return null;
+            }
+            return CourseTypeDto.builder()
+                    .id(courseType.getId())
+                    .code(courseType.getTypeCodeString())
+                    .name(courseType.getTypeName())
+                    .color(courseType.getColor())
+                    .build();
+        }
     }
 
     @Getter
@@ -48,6 +65,20 @@ public class SubjectResponse {
         private Long id;
         private String name;
         private String college;
+
+        /**
+         * Entity -> DTO 변환
+         */
+        public static DepartmentDto from(com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Department department) {
+            if (department == null) {
+                return null;
+            }
+            return DepartmentDto.builder()
+                    .id(department.getId())
+                    .name(department.getDepartmentName())
+                    .college(department.getCollege() != null ? department.getCollege().getCollegeName() : null)
+                    .build();
+        }
     }
 
     @Getter
@@ -60,6 +91,55 @@ public class SubjectResponse {
         private String subjectName;
         private Integer credits;
         private Boolean isMandatory;
+
+        /**
+         * Entity -> DTO 변환
+         */
+        public static PrerequisiteDto from(SubjectPrerequisites prerequisiteRelation) {
+            if (prerequisiteRelation == null || prerequisiteRelation.getPrerequisite() == null) {
+                return null;
+            }
+            Subject prereq = prerequisiteRelation.getPrerequisite();
+            return PrerequisiteDto.builder()
+                    .id(prereq.getId())
+                    .subjectCode(prereq.getSubjectCode())
+                    .subjectName(prereq.getSubjectName())
+                    .credits(prereq.getCredits())
+                    .isMandatory(prerequisiteRelation.getIsMandatory())
+                    .build();
+        }
+    }
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static SubjectResponse from(Subject subject) {
+        return SubjectResponse.builder()
+                .id(subject.getId())
+                .subjectCode(subject.getSubjectCode())
+                .subjectName(subject.getSubjectName())
+                .englishName(null)  // 영문명은 아직 DB에 없음
+                .credits(subject.getCredits())
+                .courseType(CourseTypeDto.from(subject.getCourseType()))
+                .department(DepartmentDto.from(subject.getDepartment()))
+                .description(subject.getDescription())
+                .prerequisites(subject.getPrerequisites() != null ?
+                        subject.getPrerequisites().stream()
+                                .map(PrerequisiteDto::from)
+                                .toList() : List.of())
+                .currentTermSections(null)  // 이 값은 서비스 레이어에서 계산 필요
+                .isActive(true)  // 기본값, 필요시 서비스 레이어에서 설정
+                .createdAt(subject.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * Entity List -> DTO List 변환
+     */
+    public static List<SubjectResponse> from(List<Subject> subjects) {
+        return subjects.stream()
+                .map(SubjectResponse::from)
+                .toList();
     }
 }
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/adapter/in/web/dto/SubjectSearchResponse.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/adapter/in/web/dto/SubjectSearchResponse.java
@@ -1,9 +1,12 @@
 package com.mzc.backend.lms.domains.course.subject.adapter.in.web.dto;
 
+import com.mzc.backend.lms.domains.course.subject.adapter.out.persistence.entity.Subject;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 /**
  * 과목 간단 검색 응답 DTO
@@ -19,5 +22,28 @@ public class SubjectSearchResponse {
     private Integer credits;
     private String courseType;  // 간단한 이름만
     private String department;  // 간단한 이름만
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static SubjectSearchResponse from(Subject subject) {
+        return SubjectSearchResponse.builder()
+                .id(subject.getId())
+                .subjectCode(subject.getSubjectCode())
+                .subjectName(subject.getSubjectName())
+                .credits(subject.getCredits())
+                .courseType(subject.getCourseType() != null ? subject.getCourseType().getTypeName() : null)
+                .department(subject.getDepartment() != null ? subject.getDepartment().getDepartmentName() : null)
+                .build();
+    }
+
+    /**
+     * Entity List -> DTO List 변환
+     */
+    public static List<SubjectSearchResponse> from(List<Subject> subjects) {
+        return subjects.stream()
+                .map(SubjectSearchResponse::from)
+                .toList();
+    }
 }
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/adapter/in/web/dto/auth/EmailAvailabilityResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/adapter/in/web/dto/auth/EmailAvailabilityResponseDto.java
@@ -6,4 +6,11 @@ package com.mzc.backend.lms.domains.user.adapter.in.web.dto.auth;
 public record EmailAvailabilityResponseDto(
         boolean available,
         String message
-) {}
+) {
+    /**
+     * 정적 팩토리 메서드
+     */
+    public static EmailAvailabilityResponseDto of(boolean available, String message) {
+        return new EmailAvailabilityResponseDto(available, message);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/adapter/in/web/dto/auth/SignupResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/adapter/in/web/dto/auth/SignupResponseDto.java
@@ -6,4 +6,11 @@ package com.mzc.backend.lms.domains.user.adapter.in.web.dto.auth;
 public record SignupResponseDto(
         String userId,
         String message
-) {}
+) {
+    /**
+     * 정적 팩토리 메서드
+     */
+    public static SignupResponseDto of(String userId, String message) {
+        return new SignupResponseDto(userId, message);
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/adapter/in/web/dto/profile/ProfileResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/adapter/in/web/dto/profile/ProfileResponseDto.java
@@ -1,6 +1,9 @@
 package com.mzc.backend.lms.domains.user.adapter.in.web.dto.profile;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Professor;
+import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Student;
+import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -44,4 +47,117 @@ public class ProfileResponseDto {
     // 학과 정보 (공통)
     private final String collegeName;
     private final String departmentName;
+
+    /**
+     * User Entity -> DTO 변환 (기본 정보만)
+     */
+    public static ProfileResponseDto from(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        ProfileResponseDtoBuilder builder = ProfileResponseDto.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .name(user.getUserProfile() != null ? user.getUserProfile().getName() : null);
+
+        // 연락처 정보
+        if (user.getPrimaryContact() != null) {
+            builder.mobileNumber(user.getPrimaryContact().getMobileNumber())
+                   .homeNumber(user.getPrimaryContact().getHomeNumber())
+                   .officeNumber(user.getPrimaryContact().getOfficeNumber())
+                   .mobileVerified(user.getPrimaryContact().getMobileVerified());
+        }
+
+        // 프로필 이미지
+        if (user.getProfileImage() != null) {
+            builder.profileImageUrl(user.getProfileImage().getImageUrl())
+                   .thumbnailUrl(user.getProfileImage().getThumbnailUrl());
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Student Entity -> DTO 변환
+     */
+    public static ProfileResponseDto from(Student student) {
+        if (student == null || student.getUser() == null) {
+            return null;
+        }
+
+        ProfileResponseDtoBuilder builder = ProfileResponseDto.builder()
+                .userId(student.getUser().getId())
+                .email(student.getUser().getEmail())
+                .name(student.getUser().getUserProfile() != null ? student.getUser().getUserProfile().getName() : null)
+                .userType("STUDENT")
+                .studentId(student.getId())
+                .admissionYear(student.getAdmissionYear())
+                .grade(student.getGrade());
+
+        // 연락처 정보
+        if (student.getUser().getPrimaryContact() != null) {
+            builder.mobileNumber(student.getUser().getPrimaryContact().getMobileNumber())
+                   .homeNumber(student.getUser().getPrimaryContact().getHomeNumber())
+                   .officeNumber(student.getUser().getPrimaryContact().getOfficeNumber())
+                   .mobileVerified(student.getUser().getPrimaryContact().getMobileVerified());
+        }
+
+        // 프로필 이미지
+        if (student.getUser().getProfileImage() != null) {
+            builder.profileImageUrl(student.getUser().getProfileImage().getImageUrl())
+                   .thumbnailUrl(student.getUser().getProfileImage().getThumbnailUrl());
+        }
+
+        // 학과 정보
+        if (student.getStudentDepartment() != null && student.getStudentDepartment().getDepartment() != null) {
+            builder.departmentName(student.getStudentDepartment().getDepartment().getDepartmentName());
+            if (student.getStudentDepartment().getDepartment().getCollege() != null) {
+                builder.collegeName(student.getStudentDepartment().getDepartment().getCollege().getCollegeName());
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Professor Entity -> DTO 변환
+     */
+    public static ProfileResponseDto from(Professor professor) {
+        if (professor == null || professor.getUser() == null) {
+            return null;
+        }
+
+        ProfileResponseDtoBuilder builder = ProfileResponseDto.builder()
+                .userId(professor.getUser().getId())
+                .email(professor.getUser().getEmail())
+                .name(professor.getUser().getUserProfile() != null ? professor.getUser().getUserProfile().getName() : null)
+                .userType("PROFESSOR")
+                .professorId(professor.getId())
+                .appointmentDate(professor.getAppointmentDate());
+
+        // 연락처 정보
+        if (professor.getUser().getPrimaryContact() != null) {
+            builder.mobileNumber(professor.getUser().getPrimaryContact().getMobileNumber())
+                   .homeNumber(professor.getUser().getPrimaryContact().getHomeNumber())
+                   .officeNumber(professor.getUser().getPrimaryContact().getOfficeNumber())
+                   .mobileVerified(professor.getUser().getPrimaryContact().getMobileVerified());
+        }
+
+        // 프로필 이미지
+        if (professor.getUser().getProfileImage() != null) {
+            builder.profileImageUrl(professor.getUser().getProfileImage().getImageUrl())
+                   .thumbnailUrl(professor.getUser().getProfileImage().getThumbnailUrl());
+        }
+
+        // 학과 정보
+        if (professor.getProfessorDepartment() != null && professor.getProfessorDepartment().getDepartment() != null) {
+            builder.departmentName(professor.getProfessorDepartment().getDepartment().getDepartmentName());
+            if (professor.getProfessorDepartment().getDepartment().getCollege() != null) {
+                builder.collegeName(professor.getProfessorDepartment().getDepartment().getCollege().getCollegeName());
+            }
+        }
+
+        return builder.build();
+    }
 }


### PR DESCRIPTION
## Summary
- course, user 도메인의 Response DTO에 정적 팩토리 메서드 `from()` 추가
- board 도메인과 동일한 패턴 적용으로 DTO 변환 로직 통일

## Changes

### Course Domain
**Subject DTOs:**
- `SubjectSearchResponse`: Subject -> DTO 변환
- `SubjectResponse`: Subject -> DTO 변환 (nested DTOs: CourseTypeDto, DepartmentDto, PrerequisiteDto)
- `SubjectDetailResponse`: Subject -> DTO 변환 (nested DTOs: CourseInfoDto, ProfessorDto, TermDto)

**Grade DTOs:**
- `StudentGradeResponseDto`: Grade -> DTO 변환
- `ProfessorCourseGradesResponseDto`: Grade -> DTO 변환 (nested DTO: StudentDto)

### User Domain
**Profile DTOs:**
- `ProfileResponseDto`: User/Student/Professor -> DTO 변환 (오버로딩)
  - from(User): 기본 사용자 정보
  - from(Student): 학생 정보 포함
  - from(Professor): 교수 정보 포함

**Auth DTOs:**
- `EmailAvailabilityResponseDto`: of() 팩토리 메서드
- `SignupResponseDto`: of() 팩토리 메서드

## Test Plan
- [x] 빌드 성공 확인
- [x] 기존 테스트 통과 확인 (테스트 스킵으로 빌드만 확인)
- [ ] 각 도메인별 통합 테스트 수행

## Notes
- enrollment 도메인의 일부 DTO는 복잡한 집계/벌크 작업 결과 DTO로, 서비스 레이어에서 직접 구성되므로 제외
- 일부 DTO는 여러 엔티티를 조합하므로, 기본 from() 메서드 + 서비스 레이어에서 추가 데이터 설정 패턴 사용