### PR TITLE
feat(dto): 나머지 도메인 정적 팩토리 메서드 추가 (#48)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/AttemptGradeResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/AttemptGradeResponseDto.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response;
 
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.AssessmentAttempt;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,17 @@ public class AttemptGradeResponseDto {
     private BigDecimal latePenaltyRate;
     private LocalDateTime gradedAt;
     private Long gradedBy;
+
+    public static AttemptGradeResponseDto from(AssessmentAttempt attempt) {
+        return AttemptGradeResponseDto.builder()
+                .attemptId(attempt.getId())
+                .score(attempt.getScore())
+                .isLate(attempt.getIsLate())
+                .latePenaltyRate(attempt.getLatePenaltyRate())
+                .gradedAt(attempt.getGradedAt())
+                .gradedBy(attempt.getGradedBy())
+                .build();
+    }
 }
 
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/AttemptStartResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/AttemptStartResponseDto.java
@@ -1,10 +1,12 @@
 package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response;
 
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.AssessmentAttempt;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Getter
 @Builder
@@ -15,6 +17,19 @@ public class AttemptStartResponseDto {
     private LocalDateTime startedAt;
     private LocalDateTime endAt;
     private Long remainingSeconds;
+
+    public static AttemptStartResponseDto from(AssessmentAttempt attempt, LocalDateTime endAt) {
+        long remainingSeconds = attempt.getStartedAt() != null && endAt != null
+                ? ChronoUnit.SECONDS.between(LocalDateTime.now(), endAt)
+                : 0L;
+
+        return AttemptStartResponseDto.builder()
+                .attemptId(attempt.getId())
+                .startedAt(attempt.getStartedAt())
+                .endAt(endAt)
+                .remainingSeconds(Math.max(0L, remainingSeconds))
+                .build();
+    }
 }
 
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/AttemptSubmitResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/AttemptSubmitResponseDto.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response;
 
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.AssessmentAttempt;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,16 @@ public class AttemptSubmitResponseDto {
     private Boolean isLate;
     private BigDecimal latePenaltyRate;
     private BigDecimal score;
+
+    public static AttemptSubmitResponseDto from(AssessmentAttempt attempt) {
+        return AttemptSubmitResponseDto.builder()
+                .attemptId(attempt.getId())
+                .submittedAt(attempt.getSubmittedAt())
+                .isLate(attempt.getIsLate())
+                .latePenaltyRate(attempt.getLatePenaltyRate())
+                .score(attempt.getScore())
+                .build();
+    }
 }
 
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/ProfessorAttemptDetailResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/ProfessorAttemptDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.AssessmentAttempt;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +39,28 @@ public class ProfessorAttemptDetailResponseDto {
      * 교수 조회는 정답 포함 원본 제공
      */
     private JsonNode questionData;
+
+    public static ProfessorAttemptDetailResponseDto from(
+            AssessmentAttempt attempt,
+            ProfessorAttemptListItemResponseDto.StudentInfo studentInfo,
+            JsonNode answerData,
+            JsonNode questionData
+    ) {
+        return ProfessorAttemptDetailResponseDto.builder()
+                .attemptId(attempt.getId())
+                .examId(attempt.getAssessment().getId())
+                .courseId(attempt.getAssessment().getCourseId())
+                .student(studentInfo)
+                .startedAt(attempt.getStartedAt())
+                .submittedAt(attempt.getSubmittedAt())
+                .isLate(attempt.getIsLate())
+                .latePenaltyRate(attempt.getLatePenaltyRate())
+                .score(attempt.getScore())
+                .feedback(attempt.getFeedback())
+                .answerData(answerData)
+                .questionData(questionData)
+                .build();
+    }
 }
 
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/ProfessorAttemptListItemResponseDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/response/ProfessorAttemptListItemResponseDto.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.response;
 
+import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.AssessmentAttempt;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +35,24 @@ public class ProfessorAttemptListItemResponseDto {
         private Long id;
         private String studentNumber;
         private String name;
+    }
+
+    public static ProfessorAttemptListItemResponseDto from(
+            AssessmentAttempt attempt,
+            StudentInfo studentInfo
+    ) {
+        return ProfessorAttemptListItemResponseDto.builder()
+                .attemptId(attempt.getId())
+                .examId(attempt.getAssessment().getId())
+                .courseId(attempt.getAssessment().getCourseId())
+                .student(studentInfo)
+                .startedAt(attempt.getStartedAt())
+                .submittedAt(attempt.getSubmittedAt())
+                .isLate(attempt.getIsLate())
+                .latePenaltyRate(attempt.getLatePenaltyRate())
+                .score(attempt.getScore())
+                .feedback(attempt.getFeedback())
+                .build();
     }
 }
 


### PR DESCRIPTION
## Summary
나머지 도메인의 Response DTO에 정적 팩토리 메서드 `from()` 추가

## 변경 사항
### Assessment 도메인
- `AttemptGradeResponseDto`: `from(AssessmentAttempt)` 추가
- `AttemptStartResponseDto`: `from(AssessmentAttempt, LocalDateTime)` 추가  
- `AttemptSubmitResponseDto`: `from(AssessmentAttempt)` 추가
- `ProfessorAttemptListItemResponseDto`: `from(AssessmentAttempt, StudentInfo)` 추가
- `ProfessorAttemptDetailResponseDto`: `from(AssessmentAttempt, StudentInfo, JsonNode, JsonNode)` 추가

### 이미 from() 메서드가 있는 도메인
- **Board**: PostResponseDto, CommentResponseDto, AttachmentResponseDto, HashtagDto, HashtagSearchResponseDto, PostListResponseDto, AssignmentResponseDto, AssignmentSubmissionResponseDto
- **Notification**: NotificationResponseDto
- **Academy**: AcademicTermResponseDto
- **Message**: ConversationResponseDto, MessageResponseDto, ConversationListResponseDto

### 정적 팩토리 메서드를 추가하지 않은 도메인
- **Enrollment**: 모든 Response DTO가 집계/일괄 처리용 DTO로 Entity 매핑 불가
- **Attendance**: 대부분 집계/통계 DTO로 Entity 매핑 불가
- **Dashboard**: JPQL projection DTO로 쿼리 결과에서 직접 생성

## 테스트 계획
- [x] 빌드 성공 확인
- [ ] 기존 테스트 통과 확인
- [ ] 코드 리뷰

## 관련 이슈
Closes #48