### PR TITLE
feat(validation): Request DTO Bean Validation 및 예외 처리 (#6)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/request/AssessmentCreateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/request/AssessmentCreateRequestDto.java
@@ -2,8 +2,10 @@ package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.request;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.mzc.backend.lms.domains.assessment.adapter.out.persistence.entity.enums.AssessmentType;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +24,11 @@ public class AssessmentCreateRequestDto {
     private Long courseId;
 
     @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
     private String title;
 
     @NotBlank(message = "설명은 필수입니다")
+    @Size(max = 5000, message = "내용은 5000자 이하여야 합니다")
     private String content;
 
     @NotNull(message = "유형은 필수입니다")
@@ -34,9 +38,11 @@ public class AssessmentCreateRequestDto {
     private LocalDateTime startAt;
 
     @NotNull(message = "제한 시간(분)은 필수입니다")
+    @Min(value = 1, message = "제한 시간은 1분 이상이어야 합니다")
     private Integer durationMinutes;
 
     @NotNull(message = "총점은 필수입니다")
+    @Min(value = 0, message = "총점은 0 이상이어야 합니다")
     private BigDecimal totalScore;
 
     @Builder.Default

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/request/AssessmentUpdateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/request/AssessmentUpdateRequestDto.java
@@ -1,6 +1,8 @@
 package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.request;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,12 +17,20 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class AssessmentUpdateRequestDto {
 
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
     private String title;
+
+    @Size(max = 5000, message = "내용은 5000자 이하여야 합니다")
     private String content;
 
     private LocalDateTime startAt;
+
+    @Min(value = 1, message = "제한 시간은 1분 이상이어야 합니다")
     private Integer durationMinutes;
+
+    @Min(value = 0, message = "총점은 0 이상이어야 합니다")
     private BigDecimal totalScore;
+
     private Boolean isOnline;
     private String location;
     private String instructions;

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/request/AttemptGradeRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/assessment/adapter/in/web/dto/request/AttemptGradeRequestDto.java
@@ -1,6 +1,8 @@
 package com.mzc.backend.lms.domains.assessment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,8 +21,10 @@ import java.math.BigDecimal;
 public class AttemptGradeRequestDto {
 
     @NotNull(message = "점수는 필수입니다")
+    @Min(value = 0, message = "점수는 0 이상이어야 합니다")
     private BigDecimal score;
 
+    @Size(max = 2000, message = "피드백은 2000자 이하여야 합니다")
     private String feedback;
 }
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/CommentCreateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/CommentCreateRequestDto.java
@@ -2,6 +2,7 @@ package com.mzc.backend.lms.domains.board.adapter.in.web.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 
 import java.util.List;
@@ -27,6 +28,7 @@ public class CommentCreateRequestDto {
     private Long parentCommentId; // null이면 일반 댓글, 값이 있으면 대댓글
 
     @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 2000, message = "댓글 내용은 2000자 이하여야 합니다")
     private String content;
 
     private List<Long> attachmentIds; // 첨부파일 ID 목록

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/CommentUpdateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/CommentUpdateRequestDto.java
@@ -2,6 +2,7 @@ package com.mzc.backend.lms.domains.board.adapter.in.web.dto.request;
 
 import java.util.List;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 public class CommentUpdateRequestDto {
 
     @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 2000, message = "댓글 내용은 2000자 이하여야 합니다")
     private String content;
 
     // 새로 추가할 첨부파일 ID 목록

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/PostCreateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/PostCreateRequestDto.java
@@ -3,6 +3,9 @@ package com.mzc.backend.lms.domains.board.adapter.in.web.dto.request;
 import java.util.List;
 
 import com.mzc.backend.lms.domains.board.adapter.out.persistence.enums.PostType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,12 +20,18 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PostCreateRequestDto {
 
+    @NotNull(message = "카테고리 ID는 필수입니다")
     private Long categoryId;
 
+    @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
     private String title;
 
+    @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 10000, message = "내용은 10000자 이하여야 합니다")
     private String content;
 
+    @NotNull(message = "게시글 유형은 필수입니다")
     private PostType postType;
 
     private Boolean isAnonymous;

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/PostUpdateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/adapter/in/web/dto/request/PostUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.board.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,12 +16,22 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostUpdateRequestDto {
+
     private Long categoryId;
+
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
     private String title;
+
+    @Size(max = 10000, message = "내용은 10000자 이하여야 합니다")
     private String content;
+
     private String postType;
+
     private Boolean isAnonymous;
+
     private List<Long> attachmentIds; // 새로 추가할 첨부파일 ID 목록
+
     private List<Long> deleteAttachmentIds; // 삭제할 첨부파일 ID 목록
+
     private List<String> hashtags;
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentCreateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentCreateRequestDto.java
@@ -1,7 +1,9 @@
 package com.mzc.backend.lms.domains.board.assignment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +24,11 @@ public class AssignmentCreateRequestDto {
 
     // Post 정보
     @NotBlank(message = "제목은 필수입니다")
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
     private String title;
 
     @NotBlank(message = "내용은 필수입니다")
+    @Size(max = 10000, message = "내용은 10000자 이하여야 합니다")
     private String content;
 
     private List<String> hashtags;
@@ -39,6 +43,7 @@ public class AssignmentCreateRequestDto {
     private LocalDateTime dueDate;
 
     @NotNull(message = "만점은 필수입니다")
+    @Min(value = 0, message = "만점은 0 이상이어야 합니다")
     private BigDecimal maxScore;
 
     @NotBlank(message = "제출 방법은 필수입니다")
@@ -47,8 +52,10 @@ public class AssignmentCreateRequestDto {
     @Builder.Default
     private Boolean lateSubmissionAllowed = false;
 
+    @Min(value = 0, message = "감점율은 0 이상이어야 합니다")
     private BigDecimal latePenaltyPercent;
 
+    @Min(value = 1, message = "최대 파일 크기는 1MB 이상이어야 합니다")
     private Integer maxFileSizeMb;
 
     private String allowedFileTypes; // comma-separated: "pdf,docx,hwp"

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentGradeRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentGradeRequestDto.java
@@ -1,6 +1,8 @@
 package com.mzc.backend.lms.domains.board.assignment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +20,9 @@ import java.math.BigDecimal;
 public class AssignmentGradeRequestDto {
 
     @NotNull(message = "점수는 필수입니다")
+    @Min(value = 0, message = "점수는 0 이상이어야 합니다")
     private BigDecimal score;
 
+    @Size(max = 2000, message = "피드백은 2000자 이하여야 합니다")
     private String feedback;
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentSubmissionRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentSubmissionRequestDto.java
@@ -1,6 +1,6 @@
 package com.mzc.backend.lms.domains.board.assignment.adapter.in.web.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +17,9 @@ import java.util.List;
 @AllArgsConstructor
 public class AssignmentSubmissionRequestDto {
 
+    @Size(max = 10000, message = "제출 내용은 10000자 이하여야 합니다")
     private String content;
-    
+
     /**
      * 첨부파일 ID 목록
      */

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentUpdateRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/board/assignment/adapter/in/web/dto/request/AssignmentUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package com.mzc.backend.lms.domains.board.assignment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,21 +20,26 @@ import java.time.LocalDateTime;
 public class AssignmentUpdateRequestDto {
 
     // Post 정보
+    @Size(max = 200, message = "제목은 200자 이하여야 합니다")
     private String title;
 
+    @Size(max = 10000, message = "내용은 10000자 이하여야 합니다")
     private String content;
 
     // Assignment 정보
     private LocalDateTime dueDate;
 
+    @Min(value = 0, message = "만점은 0 이상이어야 합니다")
     private BigDecimal maxScore;
 
     private String submissionMethod;
 
     private Boolean lateSubmissionAllowed;
 
+    @Min(value = 0, message = "감점율은 0 이상이어야 합니다")
     private BigDecimal latePenaltyPercent;
 
+    @Min(value = 1, message = "최대 파일 크기는 1MB 이상이어야 합니다")
     private Integer maxFileSizeMb;
 
     private String allowedFileTypes;

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/adapter/in/web/dto/request/CourseNoticeCommentRequest.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/adapter/in/web/dto/request/CourseNoticeCommentRequest.java
@@ -1,6 +1,7 @@
 package com.mzc.backend.lms.domains.course.notice.adapter.in.web.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 public class CourseNoticeCommentRequest {
 
     @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 2000, message = "댓글 내용은 2000자 이하여야 합니다.")
     private String content;
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/adapter/in/web/dto/request/CourseNoticeCreateRequest.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/adapter/in/web/dto/request/CourseNoticeCreateRequest.java
@@ -15,6 +15,7 @@ public class CourseNoticeCreateRequest {
     private String title;
 
     @NotBlank(message = "내용은 필수입니다.")
+    @Size(max = 5000, message = "내용은 5000자 이내여야 합니다.")
     private String content;
 
     @NotNull(message = "댓글 허용 여부는 필수입니다.")

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/adapter/in/web/dto/request/CourseNoticeUpdateRequest.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/notice/adapter/in/web/dto/request/CourseNoticeUpdateRequest.java
@@ -15,6 +15,7 @@ public class CourseNoticeUpdateRequest {
     private String title;
 
     @NotBlank(message = "내용은 필수입니다.")
+    @Size(max = 5000, message = "내용은 5000자 이내여야 합니다.")
     private String content;
 
     @NotNull(message = "댓글 허용 여부는 필수입니다.")

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/CartBulkDeleteRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/CartBulkDeleteRequestDto.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.enrollment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,5 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CartBulkDeleteRequestDto {
+
+    @NotEmpty(message = "삭제할 장바구니 ID 목록은 필수입니다")
     private List<Long> cartIds;
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/CourseIdsRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/CourseIdsRequestDto.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.enrollment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,5 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CourseIdsRequestDto {
+
+    @NotEmpty(message = "강의 ID 목록은 필수입니다")
     private List<Long> courseIds;
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/CourseSearchRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/CourseSearchRequestDto.java
@@ -1,5 +1,7 @@
 package com.mzc.backend.lms.domains.enrollment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,12 +11,23 @@ import lombok.Getter;
 @Getter
 @Builder
 public class CourseSearchRequestDto {
+
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
     private Integer page;
+
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
     private Integer size;
+
     private String keyword;
+
     private Long departmentId;
+
     private Integer courseType; // MAJOR_REQ, MAJOR_ELEC, GEN_REQ, GEN_ELEC
+
     private Integer credits;
+
+    @NotNull(message = "수강신청 기간 ID는 필수입니다")
     private Long enrollmentPeriodId; // 필수 (enrollment_periods.id)
+
     private String sort; // 기본값: courseCode,asc
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/EnrollmentBulkCancelRequestDto.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/in/web/dto/request/EnrollmentBulkCancelRequestDto.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.enrollment.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,5 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class EnrollmentBulkCancelRequestDto {
+
+    @NotEmpty(message = "취소할 수강신청 ID 목록은 필수입니다")
     private List<Long> enrollmentIds;
 }


### PR DESCRIPTION
## Summary
- 모든 Request DTO에 Bean Validation 어노테이션 추가하여 계층별 Validation 분리
- 기존 GlobalExceptionHandler(ApplicationExceptionHandler)의 MethodArgumentNotValidException 처리 활용

## Changes
### Request DTO Bean Validation 추가
- **@NotNull**: 필수 Long, Object 타입 필드
- **@NotBlank**: 필수 String 필드
- **@NotEmpty**: 필수 List 필드
- **@Size**: 문자열 길이 제한
  - 제목: 200자 이하
  - 내용: 5000~10000자 이하
  - 댓글: 2000자 이하
- **@Min**: 숫자 범위 검증
  - 점수: 0 이상
  - 페이지 번호: 0 이상
  - 페이지 크기: 1 이상
  - 제한 시간: 1분 이상

### 적용된 DTO 목록 (18개)
**Enrollment 도메인**
- EnrollmentBulkCancelRequestDto
- CourseSearchRequestDto
- CartBulkDeleteRequestDto
- CourseIdsRequestDto

**Assessment 도메인**
- AssessmentCreateRequestDto
- AssessmentUpdateRequestDto
- AttemptGradeRequestDto

**Board 도메인**
- PostCreateRequestDto
- PostUpdateRequestDto
- CommentCreateRequestDto
- CommentUpdateRequestDto

**Assignment 도메인**
- AssignmentCreateRequestDto
- AssignmentUpdateRequestDto
- AssignmentGradeRequestDto
- AssignmentSubmissionRequestDto

**Course Notice 도메인**
- CourseNoticeCreateRequest
- CourseNoticeUpdateRequest
- CourseNoticeCommentRequest

## Exception Handling
- ApplicationExceptionHandler에서 MethodArgumentNotValidException 처리 (기존 구현 활용)
- ProblemDetail 형식으로 에러 응답 반환
- 필드별 에러 메시지 포함

## Architecture
### 계층별 Validation 분리
1. **Presentation Layer (Request DTO)**
   - Bean Validation으로 형식 검증
   - @Valid 어노테이션으로 자동 검증

2. **Application Layer (Service)**
   - 비즈니스 로직 검증 (기존 방식 유지)
   - 도메인 규칙 검증

## Test Plan
- [ ] 빌드 성공 확인
- [ ] 필수 필드 누락 시 400 Bad Request 응답 확인
- [ ] 길이 초과 시 400 Bad Request 응응 확인
- [ ] 유효한 요청 시 정상 처리 확인
- [ ] ProblemDetail 형식의 에러 응답 확인

## Related Issue
Closes #6