### PR TITLE
refactor: JPA Entity 간 직접 참조를 ID 참조로 변경 (#67)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/adapter/out/persistence/entity/StudentContentProgress.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/adapter/out/persistence/entity/StudentContentProgress.java
@@ -1,7 +1,5 @@
 package com.mzc.backend.lms.domains.attendance.adapter.out.persistence.entity;
 
-import com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.WeekContent;
-import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Student;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +7,7 @@ import java.time.LocalDateTime;
 
 /**
  * 학생 콘텐츠 진행 상황 엔티티
- * student_content_progress 테이블과 매핑 (Video Streaming Server에서 관리)
+ * MSA 전환을 위해 다른 도메인 Entity 직접 참조 대신 ID만 저장
  */
 @Entity
 @Table(name = "student_content_progress",
@@ -24,13 +22,11 @@ public class StudentContentProgress {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "content_id", nullable = false)
-    private WeekContent content;
+    @Column(name = "content_id", nullable = false)
+    private Long contentId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "student_id", nullable = false)
-    private Student student;
+    @Column(name = "student_id", nullable = false)
+    private Long studentId;
 
     @Column(name = "is_completed", nullable = false)
     private Boolean isCompleted;
@@ -53,24 +49,7 @@ public class StudentContentProgress {
     @Column(name = "access_count", nullable = false)
     private Integer accessCount;
 
-    /**
-     * 콘텐츠 완료 여부 확인
-     */
     public boolean isVideoCompleted() {
         return Boolean.TRUE.equals(this.isCompleted);
-    }
-
-    /**
-     * 콘텐츠 ID 반환 (편의 메서드)
-     */
-    public Long getContentId() {
-        return this.content != null ? this.content.getId() : null;
-    }
-
-    /**
-     * 학생 ID 반환 (편의 메서드)
-     */
-    public Long getStudentId() {
-        return this.student != null ? this.student.getStudentId() : null;
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/adapter/out/persistence/entity/WeekAttendance.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/attendance/adapter/out/persistence/entity/WeekAttendance.java
@@ -1,8 +1,5 @@
 package com.mzc.backend.lms.domains.attendance.adapter.out.persistence.entity;
 
-import com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.Course;
-import com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.CourseWeek;
-import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Student;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,8 +7,7 @@ import java.time.LocalDateTime;
 
 /**
  * 주차별 출석 엔티티
- * 학생이 해당 주차의 모든 VIDEO를 완료하면 출석으로 인정
- * 완료 시점 잠금: 출석 완료된 주차는 이후 콘텐츠 변경에 영향받지 않음
+ * MSA 전환을 위해 다른 도메인 Entity 직접 참조 대신 ID만 저장
  */
 @Entity
 @Table(name = "week_attendance",
@@ -26,17 +22,14 @@ public class WeekAttendance {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "student_id", nullable = false)
-    private Student student;
+    @Column(name = "student_id", nullable = false)
+    private Long studentId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "week_id", nullable = false)
-    private CourseWeek week;
+    @Column(name = "week_id", nullable = false)
+    private Long weekId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id", nullable = false)
-    private Course course;
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
 
     @Column(name = "is_completed", nullable = false)
     @Builder.Default
@@ -58,11 +51,11 @@ public class WeekAttendance {
     /**
      * 출석 레코드 생성 팩토리 메서드
      */
-    public static WeekAttendance create(Student student, CourseWeek week, Course course, int totalVideoCount) {
+    public static WeekAttendance create(Long studentId, Long weekId, Long courseId, int totalVideoCount) {
         return WeekAttendance.builder()
-                .student(student)
-                .week(week)
-                .course(course)
+                .studentId(studentId)
+                .weekId(weekId)
+                .courseId(courseId)
                 .isCompleted(false)
                 .completedVideoCount(0)
                 .totalVideoCount(totalVideoCount)
@@ -72,7 +65,6 @@ public class WeekAttendance {
 
     /**
      * VIDEO 완료 시 진행 상황 업데이트
-     * 완료 시점 잠금: 이미 완료된 출석은 변경하지 않음
      */
     public void updateProgress(int completedVideoCount) {
         if (Boolean.TRUE.equals(this.isCompleted)) {
@@ -86,49 +78,19 @@ public class WeekAttendance {
         }
     }
 
-    /**
-     * 출석 완료 처리
-     */
     private void markAsCompleted() {
         this.isCompleted = true;
         this.completedAt = LocalDateTime.now();
     }
 
-    /**
-     * 출석 완료 여부 확인
-     */
     public boolean isAttendanceCompleted() {
         return Boolean.TRUE.equals(this.isCompleted);
     }
 
-    /**
-     * 진행률 계산 (0 ~ 100)
-     */
     public int getProgressPercentage() {
         if (this.totalVideoCount == 0) {
             return 100;
         }
         return (int) ((this.completedVideoCount * 100.0) / this.totalVideoCount);
-    }
-
-    /**
-     * 학생 ID 반환 (편의 메서드)
-     */
-    public Long getStudentId() {
-        return this.student != null ? this.student.getStudentId() : null;
-    }
-
-    /**
-     * 주차 ID 반환 (편의 메서드)
-     */
-    public Long getWeekId() {
-        return this.week != null ? this.week.getId() : null;
-    }
-
-    /**
-     * 강의 ID 반환 (편의 메서드)
-     */
-    public Long getCourseId() {
-        return this.course != null ? this.course.getId() : null;
     }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/adapter/out/persistence/CoursePersistenceAdapter.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/adapter/out/persistence/CoursePersistenceAdapter.java
@@ -67,6 +67,11 @@ public class CoursePersistenceAdapter implements CourseRepositoryPort {
     }
 
     @Override
+    public List<Course> findAllById(List<Long> ids) {
+        return courseRepository.findAllById(ids);
+    }
+
+    @Override
     public List<Course> findByIdInWithSubject(List<Long> ids) {
         return courseRepository.findByIdInWithSubject(ids);
     }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/application/port/out/CourseRepositoryPort.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/application/port/out/CourseRepositoryPort.java
@@ -59,6 +59,11 @@ public interface CourseRepositoryPort {
     List<AcademicTerm> findDistinctAcademicTermsByProfessorId(Long professorId);
 
     /**
+     * Course ID 목록으로 조회
+     */
+    List<Course> findAllById(List<Long> ids);
+
+    /**
      * Course ID 목록으로 Subject 포함 조회
      */
     List<Course> findByIdInWithSubject(List<Long> ids);

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/application/service/GradePublishService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/grade/application/service/GradePublishService.java
@@ -248,7 +248,7 @@ public class GradePublishService implements GradePublishUseCase {
         // 1) 수강생별 점수(원점수/정규화/최종점수) 전부 계산
         List<StudentGradeCalc> calcs = new ArrayList<>(enrollments.size());
         for (Enrollment e : enrollments) {
-            Long studentId = e.getStudent().getStudentId();
+            Long studentId = e.getStudentId();
 
             // 원점수 합(획득합)
             BigDecimal quizEarned = quizIds.isEmpty() ? BigDecimal.ZERO :
@@ -354,7 +354,7 @@ public class GradePublishService implements GradePublishUseCase {
         }
 
         List<Enrollment> enrollments = enrollmentPort.findByCourseIdWithStudent(courseId);
-        List<Long> studentIds = enrollments.stream().map(e -> e.getStudent().getStudentId()).toList();
+        List<Long> studentIds = enrollments.stream().map(Enrollment::getStudentId).toList();
         if (studentIds.isEmpty()) {
             log.info("성적 공개 스킵(수강생 없음) courseId={}", courseId);
             return;

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/out/persistence/EnrollmentPersistenceAdapter.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/out/persistence/EnrollmentPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.enrollment.adapter.out.persistence;
 
+import com.mzc.backend.lms.domains.course.course.application.port.out.CourseRepositoryPort;
 import com.mzc.backend.lms.domains.enrollment.application.port.out.EnrollmentRepositoryPort;
 import com.mzc.backend.lms.domains.enrollment.adapter.out.persistence.entity.Enrollment;
 import com.mzc.backend.lms.domains.enrollment.adapter.out.persistence.repository.EnrollmentRepository;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Enrollment 영속성 Adapter
@@ -17,6 +20,7 @@ import java.util.Optional;
 public class EnrollmentPersistenceAdapter implements EnrollmentRepositoryPort {
 
     private final EnrollmentRepository enrollmentRepository;
+    private final CourseRepositoryPort courseRepositoryPort;
 
     @Override
     public Enrollment save(Enrollment enrollment) {
@@ -40,8 +44,15 @@ public class EnrollmentPersistenceAdapter implements EnrollmentRepositoryPort {
 
     @Override
     public List<Enrollment> findByStudentIdAndAcademicTermId(Long studentId, Long academicTermId) {
+        // MSA 전환 대비: Course는 별도 조회
+        // 해당 학기의 Course ID 목록 조회
+        Set<Long> termCourseIds = courseRepositoryPort.findByAcademicTermId(academicTermId).stream()
+                .map(course -> course.getId())
+                .collect(Collectors.toSet());
+
+        // 학생의 수강신청 중 해당 학기 강의만 필터링
         return enrollmentRepository.findByStudentId(studentId).stream()
-                .filter(e -> e.getCourse().getAcademicTerm().getId().equals(academicTermId))
+                .filter(e -> termCourseIds.contains(e.getCourseId()))
                 .toList();
     }
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/out/persistence/entity/CourseCart.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/out/persistence/entity/CourseCart.java
@@ -4,9 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Column;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -16,15 +13,10 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Student;
-import com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.Course;
-
-
-/*
-    CourseCart 엔티티
-    course_carts 테이블과 매핑
-*/
-
+/**
+ * 수강 장바구니 엔티티
+ * MSA 전환을 위해 다른 도메인 Entity 직접 참조 대신 ID만 저장
+ */
 @Entity
 @Table(name = "course_carts")
 @Getter
@@ -35,14 +27,23 @@ public class CourseCart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "student_id", nullable = false)
-    private Student student; // 학생 ID
+    @Column(name = "student_id", nullable = false)
+    private Long studentId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id", nullable = false)
-    private Course course; // 강의 ID
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
 
     @Column(name = "added_at", nullable = false)
-    private LocalDateTime addedAt; // 담은 일시
+    private LocalDateTime addedAt;
+
+    /**
+     * 팩토리 메서드
+     */
+    public static CourseCart create(Long studentId, Long courseId) {
+        return CourseCart.builder()
+                .studentId(studentId)
+                .courseId(courseId)
+                .addedAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/out/persistence/entity/Enrollment.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/enrollment/adapter/out/persistence/entity/Enrollment.java
@@ -10,16 +10,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Column;
-
-import com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.Course;
-import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Student;
 
 import java.time.LocalDateTime;
 
+/**
+ * 수강신청 엔티티
+ * MSA 전환을 위해 다른 도메인 Entity 직접 참조 대신 ID만 저장
+ */
 @Entity
 @Table(name = "enrollments")
 @Getter
@@ -30,14 +28,23 @@ public class Enrollment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id", nullable = false)
-    private Course course; // 강의 ID
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "student_id", nullable = false)
-    private Student student; // 학생 ID
+    @Column(name = "student_id", nullable = false)
+    private Long studentId;
 
     @Column(name = "enrolled_at", nullable = false)
-    private LocalDateTime enrolledAt; // 수강신청 일시
+    private LocalDateTime enrolledAt;
+
+    /**
+     * 팩토리 메서드
+     */
+    public static Enrollment create(Long courseId, Long studentId) {
+        return Enrollment.builder()
+                .courseId(courseId)
+                .studentId(studentId)
+                .enrolledAt(LocalDateTime.now())
+                .build();
+    }
 }       


### PR DESCRIPTION
## Summary
- MSA 전환 준비를 위해 Entity 간 `@ManyToOne` 관계를 `Long` ID 참조로 변경
- 4개 Entity 수정: `Enrollment`, `CourseCart`, `WeekAttendance`, `StudentContentProgress`
- 관련 Service/Adapter 파일들 업데이트 (9개 파일)

## 변경된 Entity
| Entity | Before | After |
|--------|--------|-------|
| `Enrollment` | `@ManyToOne Course`, `@ManyToOne Student` | `Long courseId`, `Long studentId` |
| `CourseCart` | `@ManyToOne Course`, `@ManyToOne Student` | `Long courseId`, `Long studentId` |
| `WeekAttendance` | `@ManyToOne Student/CourseWeek/Course` | `Long studentId/weekId/courseId` |
| `StudentContentProgress` | `@ManyToOne WeekContent/Student` | `Long contentId/studentId` |

## 주요 변경사항
- Entity에서 다른 도메인 Entity 직접 참조 제거
- ID를 통한 간접 참조로 MSA 전환 대비
- Service/Adapter 레벨에서 필요한 정보는 별도 Port를 통해 조회

## Test plan
- [x] 컴파일 성공 확인
- [ ] 수동 테스트: 수강신청, 장바구니, 출석 기능 동작 확인
