### PR TITLE
feat(cache): Spring Cache 추상화를 활용한 Redis 캐싱 전략 적용 (#9)

### DIFF
--- a/springboot/src/main/java/com/mzc/backend/lms/common/config/CacheConfig.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/common/config/CacheConfig.java
@@ -1,0 +1,101 @@
+package com.mzc.backend.lms.common.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Redis 캐시 설정
+ *
+ * 캐시 대상별 TTL 설정:
+ * - users: 1시간 (사용자 정보, 변경 빈도 낮음)
+ * - subjects: 24시간 (과목 목록, 매우 낮음)
+ * - terms: 24시간 (학기 정보, 매우 낮음)
+ * - notificationTypes: 24시간 (알림 타입, 매우 낮음)
+ * - courses: 30분 (코스 상세, 중간 빈도)
+ * - courseTypes: 24시간 (이수구분, 매우 낮음)
+ * - colleges: 24시간 (단과대학, 매우 낮음)
+ * - departments: 24시간 (학과, 매우 낮음)
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String CACHE_USERS = "users";
+    public static final String CACHE_SUBJECTS = "subjects";
+    public static final String CACHE_TERMS = "terms";
+    public static final String CACHE_NOTIFICATION_TYPES = "notificationTypes";
+    public static final String CACHE_COURSES = "courses";
+    public static final String CACHE_COURSE_TYPES = "courseTypes";
+    public static final String CACHE_COLLEGES = "colleges";
+    public static final String CACHE_DEPARTMENTS = "departments";
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // ObjectMapper 설정 (Java 8 날짜 지원 + 타입 정보 포함)
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        // 기본 캐시 설정 (30분)
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))
+                .disableCachingNullValues();
+
+        // 캐시별 TTL 설정
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        // 사용자 정보 - 1시간
+        cacheConfigurations.put(CACHE_USERS, defaultConfig.entryTtl(Duration.ofHours(1)));
+
+        // 과목 목록 - 24시간
+        cacheConfigurations.put(CACHE_SUBJECTS, defaultConfig.entryTtl(Duration.ofHours(24)));
+
+        // 학기 정보 - 24시간
+        cacheConfigurations.put(CACHE_TERMS, defaultConfig.entryTtl(Duration.ofHours(24)));
+
+        // 알림 타입 - 24시간
+        cacheConfigurations.put(CACHE_NOTIFICATION_TYPES, defaultConfig.entryTtl(Duration.ofHours(24)));
+
+        // 코스 상세 - 30분 (기본값)
+        cacheConfigurations.put(CACHE_COURSES, defaultConfig.entryTtl(Duration.ofMinutes(30)));
+
+        // 이수구분 - 24시간
+        cacheConfigurations.put(CACHE_COURSE_TYPES, defaultConfig.entryTtl(Duration.ofHours(24)));
+
+        // 단과대학 - 24시간
+        cacheConfigurations.put(CACHE_COLLEGES, defaultConfig.entryTtl(Duration.ofHours(24)));
+
+        // 학과 - 24시간
+        cacheConfigurations.put(CACHE_DEPARTMENTS, defaultConfig.entryTtl(Duration.ofHours(24)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .transactionAware()
+                .build();
+    }
+}

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/academy/application/service/AcademicTermQueryService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/academy/application/service/AcademicTermQueryService.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.academy.application.service;
 
+import com.mzc.backend.lms.common.config.CacheConfig;
 import com.mzc.backend.lms.domains.academy.adapter.in.web.dto.AcademicTermResponseDto;
 import com.mzc.backend.lms.domains.academy.application.port.in.AcademicTermQueryUseCase;
 import com.mzc.backend.lms.domains.academy.application.port.out.AcademicTermRepositoryPort;
@@ -7,6 +8,7 @@ import com.mzc.backend.lms.domains.academy.domain.model.AcademicTermDomain;
 import com.mzc.backend.lms.domains.academy.exception.AcademyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,7 @@ public class AcademicTermQueryService implements AcademicTermQueryUseCase {
     private final AcademicTermRepositoryPort academicTermRepositoryPort;
 
     @Override
+    @Cacheable(value = CacheConfig.CACHE_TERMS, key = "'current:' + #today")
     public AcademicTermResponseDto getCurrentAcademicTerm(LocalDate today) {
         AcademicTermDomain academicTerm = academicTermRepositoryPort.findCurrentTerms(today).stream()
                 .findFirst()
@@ -33,6 +36,7 @@ public class AcademicTermQueryService implements AcademicTermQueryUseCase {
     }
 
     @Override
+    @Cacheable(value = CacheConfig.CACHE_TERMS, key = "#id")
     public AcademicTermResponseDto getAcademicTermById(Long id) {
         AcademicTermDomain academicTerm = academicTermRepositoryPort.findById(id)
                 .orElseThrow(() -> AcademyException.semesterNotFound(id));

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/application/service/CourseService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/application/service/CourseService.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.course.course.application.service;
 
+import com.mzc.backend.lms.common.config.CacheConfig;
 import com.mzc.backend.lms.domains.course.course.application.port.in.CourseQueryUseCase;
 import com.mzc.backend.lms.domains.course.course.application.port.out.CourseRepositoryPort;
 import com.mzc.backend.lms.domains.course.course.application.port.out.CourseWeekRepositoryPort;
@@ -19,6 +20,7 @@ import com.mzc.backend.lms.domains.academy.adapter.out.persistence.entity.Enroll
 import com.mzc.backend.lms.domains.course.exception.CourseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -338,6 +340,7 @@ public class CourseService implements CourseQueryUseCase {
      * 강의 상세 정보 조회
      */
     @Override
+    @Cacheable(value = CacheConfig.CACHE_COURSES, key = "#courseId")
     public CourseDetailDto getCourseDetail(Long courseId) {
         if(courseId == null) {
             throw CourseException.courseIdRequired();

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/application/service/ProfessorCourseService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/course/application/service/ProfessorCourseService.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.course.course.application.service;
 
+import com.mzc.backend.lms.common.config.CacheConfig;
 import com.mzc.backend.lms.domains.academy.adapter.out.persistence.entity.AcademicTerm;
 import com.mzc.backend.lms.domains.academy.adapter.out.persistence.entity.EnrollmentPeriod;
 import com.mzc.backend.lms.domains.course.course.application.port.in.ProfessorCourseUseCase;
@@ -22,6 +23,7 @@ import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Departmen
 import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Professor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -386,6 +388,7 @@ public class ProfessorCourseService implements ProfessorCourseUseCase {
      * 강의 수정
      */
     @Override
+    @CacheEvict(value = CacheConfig.CACHE_COURSES, key = "#courseId")
     public CreateCourseResponseDto updateCourse(Long courseId, UpdateCourseRequestDto request, Long professorId) {
         log.info("강의 수정 요청: courseId={}, professorId={}", courseId, professorId);
 
@@ -508,6 +511,7 @@ public class ProfessorCourseService implements ProfessorCourseUseCase {
      * 강의 취소
      */
     @Override
+    @CacheEvict(value = CacheConfig.CACHE_COURSES, key = "#courseId")
     public void cancelCourse(Long courseId, Long professorId) {
         log.info("강의 취소 요청: courseId={}, professorId={}", courseId, professorId);
 

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/application/service/SubjectServiceImpl.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/course/subject/application/service/SubjectServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.course.subject.application.service;
 
+import com.mzc.backend.lms.common.config.CacheConfig;
 import com.mzc.backend.lms.domains.course.course.adapter.out.persistence.entity.CourseType;
 import com.mzc.backend.lms.domains.course.exception.CourseException;
 import com.mzc.backend.lms.domains.course.subject.application.port.in.SubjectUseCase;
@@ -13,6 +14,7 @@ import com.mzc.backend.lms.domains.course.subject.adapter.out.persistence.entity
 import com.mzc.backend.lms.domains.course.subject.adapter.out.persistence.entity.SubjectPrerequisites;
 import com.mzc.backend.lms.domains.user.adapter.out.persistence.entity.Department;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -86,6 +88,7 @@ public class SubjectServiceImpl implements SubjectUseCase {
     }
 
     @Override
+    @Cacheable(value = CacheConfig.CACHE_SUBJECTS, key = "#subjectId")
     public SubjectDetailResponse getSubjectDetail(Long subjectId) {
         Subject subject = subjectRepository.findByIdWithDetails(subjectId)
                 .orElseThrow(() -> CourseException.subjectNotFound(subjectId));

--- a/springboot/src/main/java/com/mzc/backend/lms/domains/user/application/service/UserSearchService.java
+++ b/springboot/src/main/java/com/mzc/backend/lms/domains/user/application/service/UserSearchService.java
@@ -1,5 +1,6 @@
 package com.mzc.backend.lms.domains.user.application.service;
 
+import com.mzc.backend.lms.common.config.CacheConfig;
 import com.mzc.backend.lms.domains.user.adapter.in.web.dto.search.CollegeListResponseDto;
 import com.mzc.backend.lms.domains.user.adapter.in.web.dto.search.DepartmentListResponseDto;
 import com.mzc.backend.lms.domains.user.adapter.in.web.dto.search.UserSearchCursorResponseDto;
@@ -14,6 +15,7 @@ import com.mzc.backend.lms.domains.user.application.port.out.CollegeQueryPort;
 import com.mzc.backend.lms.domains.user.application.port.out.DepartmentQueryPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,6 +68,7 @@ public class UserSearchService implements SearchUsersUseCase, GetCollegesUseCase
     }
 
     @Override
+    @Cacheable(value = CacheConfig.CACHE_COLLEGES, key = "'all'")
     public List<CollegeListResponseDto> getAllColleges() {
         return collegeQueryPort.findAll().stream()
                 .map(CollegeListResponseDto::from)
@@ -73,6 +76,7 @@ public class UserSearchService implements SearchUsersUseCase, GetCollegesUseCase
     }
 
     @Override
+    @Cacheable(value = CacheConfig.CACHE_DEPARTMENTS, key = "'college:' + #collegeId")
     public List<DepartmentListResponseDto> getDepartmentsByCollegeId(Long collegeId) {
         return departmentQueryPort.findByCollegeId(collegeId).stream()
                 .map(DepartmentListResponseDto::from)
@@ -80,6 +84,7 @@ public class UserSearchService implements SearchUsersUseCase, GetCollegesUseCase
     }
 
     @Override
+    @Cacheable(value = CacheConfig.CACHE_DEPARTMENTS, key = "'all'")
     public List<DepartmentListResponseDto> getAllDepartments() {
         return departmentQueryPort.findAll().stream()
                 .map(DepartmentListResponseDto::from)


### PR DESCRIPTION
## Summary
- Spring Cache 추상화(@Cacheable, @CacheEvict)를 활용한 Redis 캐싱 전략 구현
- TTL 기반 캐시 설정으로 데이터 특성에 맞는 캐시 만료 시간 적용
- 조회 빈도가 높고 변경이 적은 참조 데이터에 캐싱 적용

## Changes

### CacheConfig
- `CacheManager` Bean 설정 (Redis + Jackson 직렬화)
- 캐시별 TTL 설정:
  - `users`: 1시간
  - `subjects`, `terms`, `notificationTypes`, `courseTypes`, `colleges`, `departments`: 24시간
  - `courses`: 30분

### @Cacheable 적용
| Service | Method | Cache Name |
|---------|--------|------------|
| AcademicTermQueryService | getCurrentAcademicTerm, getAcademicTermById | terms |
| UserSearchService | getAllColleges, getDepartmentsByCollegeId, getAllDepartments | colleges, departments |
| CourseService | getCourseDetail | courses |
| SubjectServiceImpl | getSubjectDetail | subjects |

### @CacheEvict 적용
| Service | Method | Cache Name |
|---------|--------|------------|
| ProfessorCourseService | updateCourse, cancelCourse | courses |

## Test plan
- [x] 컴파일 성공 확인
- [x] 기존 테스트 통과 확인
- [ ] Redis 연결 후 캐시 적중률 모니터링